### PR TITLE
Mult and Histo Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ include_directories(${PROJECT_SOURCE_DIR}/include
                     ${ROOT_INCLUDE_DIRS})
 add_subdirectory(TGlauber)
 link_directories(${ROOT_LIBRARY_DIR})
-file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/FermiBreakUp/*.cc ${PROJECT_SOURCE_DIR}/Evaporation/src/*.cc ${PROJECT_SOURCE_DIR}/Fission/src/*.cc)
-file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh ${PROJECT_SOURCE_DIR}/FermiBreakUp/*.hh ${PROJECT_SOURCE_DIR}/Evaporation/include/*.hh ${PROJECT_SOURCE_DIR}/Fission/include/*.hh)
+file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/FermiBreakUp/*.cc ${PROJECT_SOURCE_DIR}/Evaporation/src/*.cc ${PROJECT_SOURCE_DIR}/Fission/src/*.cc ${PROJECT_SOURCE_DIR}/Multifragmentation/src/*.cc)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.hh ${PROJECT_SOURCE_DIR}/FermiBreakUp/*.hh ${PROJECT_SOURCE_DIR}/Evaporation/include/*.hh ${PROJECT_SOURCE_DIR}/Fission/include/*.hh ${PROJECT_SOURCE_DIR}/Multifragmentation/include/*.hh)
 
 #----------------------------------------------------------------------------
 # Add the executable, and link it to the Geant4 libraries

--- a/GRATE.cc
+++ b/GRATE.cc
@@ -54,433 +54,444 @@
 
 int main()
 {
-   //Seting parameters for Deexcitation
-  G4NuclearLevelData* fLevelData = G4NuclearLevelData::GetInstance(); 
-  G4DeexPrecoParameters* fParam = fLevelData->GetParameters();
-  //fParam->SetDeexModelType(0);
-  fParam->SetMinExPerNucleounForMF(4.*MeV); 
+    //Seting parameters for Deexcitation
+    G4NuclearLevelData* fLevelData = G4NuclearLevelData::GetInstance(); 
+    G4DeexPrecoParameters* fParam = fLevelData->GetParameters();
+    //fParam->SetDeexModelType(0);
+    fParam->SetMinExPerNucleounForMF(4.*MeV); 
 
-  G4StateManager* fStateManager = G4StateManager::GetStateManager();
-   
- // G4Random::setTheEngine(new CLHEP::RanluxEngine());
+    G4StateManager* fStateManager = G4StateManager::GetStateManager();
 
-  //auto seed1 = 0x7ffce81312f0;
-  CLHEP::HepRandom::setTheSeeds(CLHEP::HepRandom::getTheSeeds());
-  //CLHEP::HepRandom::setTheSeed(seed1);
+    // G4Random::setTheEngine(new CLHEP::RanluxEngine());
 
-  CLHEP::HepRandom::setTheEngine(new CLHEP::RanecuEngine);
-  CLHEP::RandFlat randFlat(new CLHEP::RanecuEngine);
+    //auto seed1 = 0x7ffce81312f0;
+    CLHEP::HepRandom::setTheSeeds(CLHEP::HepRandom::getTheSeeds());
+    //CLHEP::HepRandom::setTheSeed(seed1);
 
-  G4RunManager * runManager = new G4RunManager;
-  runManager->SetUserInitialization(new GRATEPhysicsList);
-  G4BosonConstructor pCBos;
-  pCBos.ConstructParticle();
- 
-  G4LeptonConstructor pCLept;
-  pCLept.ConstructParticle();
+    CLHEP::HepRandom::setTheEngine(new CLHEP::RanecuEngine);
+    CLHEP::RandFlat randFlat(new CLHEP::RanecuEngine);
 
-  G4MesonConstructor pCMes;
-  pCMes.ConstructParticle();
+    G4RunManager * runManager = new G4RunManager;
+    runManager->SetUserInitialization(new GRATEPhysicsList);
+    G4BosonConstructor pCBos;
+    pCBos.ConstructParticle();
 
-  G4BaryonConstructor pCBar;
-  pCBar.ConstructParticle();
+    G4LeptonConstructor pCLept;
+    pCLept.ConstructParticle();
 
-  G4IonConstructor pCIon;
-  pCIon.ConstructParticle();
+    G4MesonConstructor pCMes;
+    pCMes.ConstructParticle();
 
-  G4GenericIon* gion = G4GenericIon::GenericIon();
-  gion->SetProcessManager(new G4ProcessManager(gion));
+    G4BaryonConstructor pCBar;
+    pCBar.ConstructParticle();
 
-  G4StateManager::GetStateManager()->SetNewState(G4State_Init); // To let create ions
-  G4ParticleTable* partTable = G4ParticleTable::GetParticleTable();
-  G4IonTable* ions = partTable->GetIonTable();
-  partTable->SetReadiness();
-  ions->CreateAllIon();
-  ions->CreateAllIsomer();
+    G4IonConstructor pCIon;
+    pCIon.ConstructParticle();
 
-  // The user will be asked for the nuclear name to simulate it's collisions.
-  GRATEmanager histoManager;
- 
-  //arrays for tree creation
-  std::vector<G4float> MassOnSideA;
-  std::vector<G4float> MassOnSideB;
-  std::vector<G4float> ChargeOnSideA;
-  std::vector<G4float> ChargeOnSideB;
-  std::vector<G4double> pXonSideA;
-  std::vector<G4double> pYonSideA;
-  std::vector<G4double> pZonSideA;
-  std::vector<G4double> pXonSideB;
-  std::vector<G4double> pYonSideB;
-  std::vector<G4double> pZonSideB;
-  std::vector<G4double> pseudorapidity_A;
-  std::vector<G4double> pseudorapidity_B;
-  G4float b;
-  G4float ExEn;
-  G4int id;
-  G4int Nhard;
-  G4int Ncoll;
-  G4int Ncollpp;
-  G4int Ncollpn;
-  G4int Ncollnn;
-  G4int Npart;
-  G4int NpartA;
-  G4int NpartB;
-  G4int ClustNumA;
-  G4int ClustNumB;
-  G4double d_MstA;
-  G4double d_MstB;
+    G4GenericIon* gion = G4GenericIon::GenericIon();
+    gion->SetProcessManager(new G4ProcessManager(gion));
 
+    G4StateManager::GetStateManager()->SetNewState(G4State_Init); // To let create ions
+    G4ParticleTable* partTable = G4ParticleTable::GetParticleTable();
+    G4IonTable* ions = partTable->GetIonTable();
+    partTable->SetReadiness();
+    ions->CreateAllIon();
+    ions->CreateAllIsomer();
 
-  G4float PhiRotA;
-  G4float ThetaRotA;
-  G4float PhiRotB;
-  G4float ThetaRotB;
-  G4float Ecc[10] = {0};
+    // The user will be asked for the nuclear name to simulate it's collisions.
+    GRATEmanager histoManager;
 
-  std::vector<G4int> A_cl;
-  std::vector<G4int> Z_cl;
-  std::vector<G4int> Ab_cl;
-  std::vector<G4int> Zb_cl;
+    //arrays for tree creation
+    std::vector<G4float> MassOnSideA;
+    std::vector<G4float> MassOnSideB;
+    std::vector<G4float> ChargeOnSideA;
+    std::vector<G4float> ChargeOnSideB;
+    std::vector<G4double> pXonSideA;
+    std::vector<G4double> pYonSideA;
+    std::vector<G4double> pZonSideA;
+    std::vector<G4double> pXonSideB;
+    std::vector<G4double> pYonSideB;
+    std::vector<G4double> pZonSideB;
+    std::vector<G4double> pseudorapidity_A;
+    std::vector<G4double> pseudorapidity_B;
+    G4float b;
+    G4float ExEn;
+    G4int id;
+    G4int Nhard;
+    G4int Ncoll;
+    G4int Ncollpp;
+    G4int Ncollpn;
+    G4int Ncollnn;
+    G4int Npart;
+    G4int NpartA;
+    G4int NpartB;
 
-  // Histograms will be booked now.
-  histoManager.BookHisto();
-  histoManager.GetTree()->Branch("id", &id, "id/i");
-  histoManager.GetTree()->Branch("A_on_A", "std::vector" ,&MassOnSideA);
-  histoManager.GetTree()->Branch("A_on_B", "std::vector" ,&MassOnSideB);
-  histoManager.GetTree()->Branch("Z_on_A", "std::vector" ,&ChargeOnSideA);
-  histoManager.GetTree()->Branch("Z_on_B", "std::vector" ,&ChargeOnSideB);
-  histoManager.GetTree()->Branch("Nhard", &Nhard, "Nhard/I");
-  //histoManager.GetTree()->Branch("Nvoid", &Nvoid, "Nvoid/I");
-  histoManager.GetTree()->Branch("Ncoll", &Ncoll, "Ncoll/I");
-  histoManager.GetTree()->Branch("Ncollpp", &Ncollpp, "Ncollpp/I");
-  histoManager.GetTree()->Branch("Ncollpn", &Ncollpn, "Ncollpn/I");
-  histoManager.GetTree()->Branch("Ncollnn", &Ncollnn, "Ncollnn/I");
-  histoManager.GetTree()->Branch("Npart", &Npart, "Npart/I");
-  histoManager.GetTree()->Branch("NpartA", &NpartA, "NpartA/I");
-  histoManager.GetTree()->Branch("NpartB", &NpartB, "NpartB/I");
+    // FermiMom Tree
+    G4double FermiMomA_x;
+    G4double FermiMomA_y;
+    G4double FermiMomB_x;
+    G4double FermiMomB_y;
 
+    G4float PhiRotA;
+    G4float ThetaRotA;
+    G4float PhiRotB;
+    G4float ThetaRotB;
+    G4float Ecc[10] = {0};
 
+    // MST Tree
+    G4int ClustNumA;
+    G4int ClustNumB;
+    G4double d_MstA;
+    G4double d_MstB;
+    std::vector<G4int> A_cl;
+    std::vector<G4int> Z_cl;
+    std::vector<G4int> Ab_cl;
+    std::vector<G4int> Zb_cl;
 
-  histoManager.GetTreeMST()->Branch("A_cl", "std::vector" ,&A_cl);
-  histoManager.GetTreeMST()->Branch("Z_cl", "std::vector" ,&Z_cl);
-  histoManager.GetTreeMST()->Branch("d", &d_MstA ,"d/d");
-  histoManager.GetTreeMST()->Branch("Clust_num", &ClustNumA ,"Clust_num/I");
-  histoManager.GetTreeMST()->Branch("Ab_cl", "std::vector" ,&Ab_cl);
-  histoManager.GetTreeMST()->Branch("Zb_cl", "std::vector" ,&Zb_cl);
-  histoManager.GetTreeMST()->Branch("d_b", &d_MstB ,"d/d");
-  histoManager.GetTreeMST()->Branch("Clust_num_b", &ClustNumB ,"Clust_num_b/I");
+    // Histograms will be booked now.
+    histoManager.BookHisto();
+    histoManager.GetTree()->Branch("id", &id, "id/i");
+    histoManager.GetTree()->Branch("A_on_A", "std::vector" ,&MassOnSideA);
+    histoManager.GetTree()->Branch("A_on_B", "std::vector" ,&MassOnSideB);
+    histoManager.GetTree()->Branch("Z_on_A", "std::vector" ,&ChargeOnSideA);
+    histoManager.GetTree()->Branch("Z_on_B", "std::vector" ,&ChargeOnSideB);
+    histoManager.GetTree()->Branch("Nhard", &Nhard, "Nhard/I");
+    //histoManager.GetTree()->Branch("Nvoid", &Nvoid, "Nvoid/I");
+    histoManager.GetTree()->Branch("Ncoll", &Ncoll, "Ncoll/I");
+    histoManager.GetTree()->Branch("Ncollpp", &Ncollpp, "Ncollpp/I");
+    histoManager.GetTree()->Branch("Ncollpn", &Ncollpn, "Ncollpn/I");
+    histoManager.GetTree()->Branch("Ncollnn", &Ncollnn, "Ncollnn/I");
+    histoManager.GetTree()->Branch("Npart", &Npart, "Npart/I");
+    histoManager.GetTree()->Branch("NpartA", &NpartA, "NpartA/I");
+    histoManager.GetTree()->Branch("NpartB", &NpartB, "NpartB/I");
 
-if(histoManager.WritePseudorapidity()){
-  histoManager.GetTree()->Branch("pseudorapidity_on_A", "std::vector", &pseudorapidity_A);
-  histoManager.GetTree()->Branch("pseudorapidity_on_B", "std::vector", &pseudorapidity_B);
-  }
-if(histoManager.WriteMomentum()){
-  histoManager.GetTree()->Branch("pX_on_A", "std::vector" ,&pXonSideA,128000,1);
-  histoManager.GetTree()->Branch("pY_on_A", "std::vector" ,&pYonSideA,128000,1);
-  histoManager.GetTree()->Branch("pZ_on_A", "std::vector" ,&pZonSideA,128000,1);
-  histoManager.GetTree()->Branch("pX_on_B", "std::vector" ,&pXonSideB,128000,1);
-  histoManager.GetTree()->Branch("pY_on_B", "std::vector" ,&pYonSideB,128000,1);
-  histoManager.GetTree()->Branch("pZ_on_B", "std::vector" ,&pZonSideB,128000,1);
-}
+    histoManager.GetTreeMST()->Branch("A_cl", "std::vector" ,&A_cl);
+    histoManager.GetTreeMST()->Branch("Z_cl", "std::vector" ,&Z_cl);
+    histoManager.GetTreeMST()->Branch("d", &d_MstA ,"d/d");
+    histoManager.GetTreeMST()->Branch("Clust_num", &ClustNumA ,"Clust_num/I");
+    histoManager.GetTreeMST()->Branch("Ab_cl", "std::vector" ,&Ab_cl);
+    histoManager.GetTreeMST()->Branch("Zb_cl", "std::vector" ,&Zb_cl);
+    histoManager.GetTreeMST()->Branch("d_b", &d_MstB ,"d/d");
+    histoManager.GetTreeMST()->Branch("Clust_num_b", &ClustNumB ,"Clust_num_b/I");
 
-histoManager.GetTree()->Branch("impact_parameter", &b, "impact_parameter/f");
-
-histoManager.GetTree()->Branch("PhiRotA", &PhiRotA, "PhiRotA/f");
-histoManager.GetTree()->Branch("ThetaRotA", &ThetaRotA, "ThetaRotA/f");
-histoManager.GetTree()->Branch("PhiRotB", &PhiRotB, "PhiRotB/f");
-histoManager.GetTree()->Branch("ThetaRotB", &ThetaRotB, "ThetaRotB/f");
-histoManager.GetTree()->Branch("Ecc", &Ecc, "Ecc[10]/f");
-
-histoManager.GetTree()->Branch("Ex_En_per_nucleon", &ExEn, "Ex_En_per_nucleon/f");
-
-//Get Z and A of nuclei
-G4int sourceA = histoManager.GetInitialContidions().GetSourceA();
-G4int sourceAb = histoManager.GetInitialContidions().GetSourceAb();
-G4double rA_plus_rB = 1.3*(pow(G4double(sourceA),0.3333333)+pow(G4double(sourceAb),0.3333333));
-
-//START OF THE MODELLING
-//Setting up GMST
-GMSTClustering* clusters = new GMSTClustering(histoManager.GetCriticalDistance(),sourceA,sourceAb);
-clusters->SetCD(histoManager.GetCriticalDistance());
-
-//Setting up ExcitationHandler
-DeexcitationHandler* handlerNew = new DeexcitationHandler();
-//handlerNew->SetMinEForMultiFrag(3*MeV);
-handlerNew->SetMaxAandZForFermiBreakUp(19, 9);
-handlerNew->SetMinExcitation(0.0001);
-//Setting up Glauber code
-histoManager.CalcXsectNN();
-G4float omega = -1;
-G4float signn = histoManager.GetXsectNN();
-auto seed = static_cast<unsigned long int>(*CLHEP::HepRandom::getTheSeeds()); //setting the same seed to TGlauber
-
-TGlauberMC *mcg=new TGlauberMC(histoManager.GetInitialContidions().GetSysA(),histoManager.GetInitialContidions().GetSysB(),signn,omega,seed);
-mcg->SetMinDistance(0.4);
-//mcg->SetNodeDistance(0);
-mcg->SetCalcLength(0);
-mcg->SetCalcArea(0);
-mcg->SetCalcCore(0);
-mcg->SetDetail(99);
-
-if((histoManager.GetUpB() > 0 && histoManager.GetLowB() >= 0) && (histoManager.GetUpB() > histoManager.GetLowB()) && histoManager.GetUpB() < rA_plus_rB+7.5) {
-    mcg->SetBmin(histoManager.GetLowB());
-    mcg->SetBmax(histoManager.GetUpB());
-   } 
-else {std::cout << " \n------>Calculation will be MB \n"<<std::endl; }
- 
-  //Setting Excitation Energy
-  ExcitationEnergy* ExEnA = new ExcitationEnergy(histoManager.GetStatType(), sourceA);
-  ExcitationEnergy* ExEnB = new ExcitationEnergy(histoManager.GetStatType(), sourceAb);
-
-  if(histoManager.GetStatType()> 2){
-  //Parameters for ALADIN parametrization
-  G4double e_0=11.5*MeV;//was 8.13 MeV
-  G4double sigma0 = 0.005; //was 0.01
-  G4double c0 = 2; // From Bondorf 1995
-  G4double sigmaE0 = 1*MeV;
-  G4double b0 = 0.1;
-  G4double Pe = 24*MeV;
-  G4double Pm = 0.2;
-  ExEnA->SetParametersALADIN(e_0,sigma0,c0);
-  ExEnB->SetParametersALADIN(e_0,sigma0,c0);
-  ExEnA->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
-  ExEnB->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
-  //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
-  //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
-  }
-
-  NucleonVector nV;
-  GlauberCollisionReader reader;
-  FermiMomentum FermiMom(&nV, "M");
-  FermiMom.SetPzPerNucleon(histoManager.GetInitialContidions().GetPzA()/ sourceA, histoManager.GetInitialContidions().GetPzB() / sourceAb);
-
-for(G4int count=0;count<histoManager.GetIterations() ;count++){ 
-  id = count;
-  //An event generated by GlauberMC is here.
-   mcg->Run(1);
-
-  histoManager.CalcNucleonDensity(mcg->GetNucleons(), mcg->GetB());
-  //Side A $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
-  TGlauNucleus *nucA   = mcg->GetNucleusA(); 
-  TGlauNucleus *nucB = mcg->GetNucleusB();
-  NpartA = mcg->GetNpartA(); 
-  NpartB = mcg->GetNpartB();
-  Npart = mcg->GetNpart();
-  b = mcg->GetB();
-  PhiRotA = nucA->GetPhiRot();
-  ThetaRotA = nucA->GetThetaRot();
-  PhiRotB = nucB->GetPhiRot();
-  ThetaRotB = nucB->GetThetaRot();
-  for(int k = 0; k<10; k++){Ecc[k] = mcg->GetEcc(k);}
-  Nhard = mcg->GetNhard();
-  Ncoll = mcg->GetNcoll();
-  Ncollpp = mcg->GetNcollpp();
-  Ncollpn = mcg->GetNcollpn();
-  Ncollnn = mcg->GetNcollnn();
-  TObjArray* nucleons=mcg->GetNucleons();
-
-  G4int A = 0;
-  G4int Z = 0;
-  G4int Ab = 0;
-  G4int Zb = 0;
-
-  reader.Read(nucleons);
-  nV = reader.GetNucleons();
-  Z = nV.GetZ("A"); A = nV.GetA("A"); Zb = nV.GetZ("B"); Ab = nV.GetA("B");
-
-    if(!(A == 0 && Ab ==0)) {
-    G4int thisEventNumFragments = 0;
-    std::cout.setf(std::ios::scientific, std::ios::floatfield);
-    CLHEP::RandGauss randGauss(0, 1);
-
-    // Excitation energy is calculated only for unstable clusters
-    G4double energy_A = ExEnA->GetEnergy(A);
-    G4double energy_B = ExEnB->GetEnergy(Ab);
-    ExEn = energy_A/G4double(A);
-    histoManager.GetHisto2(1)->Fill(ExEn, G4double(A)/sourceA);
-
-    std::vector<G4FragmentVector> MstClustersVector = clusters->GetClusters(&nV, energy_A, energy_B, FermiMom.GetBoost("A"), FermiMom.GetBoost("B")); //d = const if energy is negative
-    G4FragmentVector clusters_to_excit_A = MstClustersVector.at(0);
-    G4FragmentVector clusters_to_excit_B = MstClustersVector.at(1);
-    d_MstA = clusters->GetCD("A");
-    d_MstB = clusters->GetCD("B");
-
-    ClustNumB = Ab_cl.size();
-
-    histoManager.GetTreeMST()->Fill();
-    A_cl.clear();
-    Z_cl.clear();
-    Ab_cl.clear();
-    Zb_cl.clear();
-
-      for(G4int i = 0; i < MstClustersVector.at(0).size(); ++i) {
-
-	  G4Fragment aFragment = (*MstClustersVector.at(0).at(i));
-      G4LorentzVector p4 = aFragment.GetMomentum();
-      //if((aFragment.GetMomentum().m() - G4NucleiProperties::GetNuclearMass(aFragment.GetA(), aFragment.GetZ()) - ExEn*aFragment.GetA() !=0) && aFragment.GetA() != 1){std::cout<<"dE_x = "<<(aFragment.GetMomentum().m() - G4NucleiProperties::GetNuclearMass(aFragment.GetA(), aFragment.GetZ()))/aFragment.GetA() - ExEn<<"\n";}
-      A_cl.push_back(aFragment.GetA());
-      Z_cl.push_back(aFragment.GetZ());
-          G4double eta_A = 0;
-      //if(abs(p4.px()) < 1) std::cout<<G4double(clfrag_A)<<" "<<G4double(sourceA)<<"\n";
-
-      // TODO Devise the source of a differences between models
-      //    - Issues in propagation of Excitation energy through GMSTClustering
-      // HANDLER
-      G4ReactionProductVector *theProduct = handlerNew->BreakUp(aFragment);
-
-      thisEventNumFragments = theProduct->size();
-
-      histoManager.GetHisto(1)->Fill(thisEventNumFragments);
-
-      for (G4ReactionProductVector::iterator iVector = theProduct->begin(); iVector != theProduct->end(); ++iVector) {
-         G4double thisFragmentZ = 0;
-         G4double thisFragmentA = 0;
-
-         const G4ParticleDefinition *pd = (*iVector)->GetDefinition();
-
-         G4String particleEmitted = pd->GetParticleName();
-
-         if (particleEmitted != "gamma" && particleEmitted != "e-" && particleEmitted != "e+") {
-             thisFragmentZ = pd->GetAtomicNumber();
-             thisFragmentA = pd->GetAtomicMass();
-             if (pd->GetAtomicMass() == 0) { G4cout << "ERROR, pn = " << pd->GetParticleName() << G4endl; }
-             MassOnSideA.push_back(thisFragmentA);
-             ChargeOnSideA.push_back(thisFragmentZ);
-
-             G4double eeA = (*iVector)->GetTotalEnergy();
-             G4LorentzVector product_p4((*iVector)->GetMomentum().x(), (*iVector)->GetMomentum().y(),
-                                        (*iVector)->GetMomentum().z(), eeA);
-             G4double pXonA = product_p4.x() / MeV;
-             G4double pYonA = product_p4.y() / MeV;
-             G4double pZonA = product_p4.z() / MeV;
-             p4 = p4 - product_p4;
-
-             eta_A = 0.5 * log((std::sqrt(pXonA * pXonA + pYonA * pYonA + pZonA * pZonA) + pZonA) /
-                               (std::sqrt(pXonA * pXonA + pYonA * pYonA + pZonA * pZonA) - pZonA));
-
-             pXonSideA.push_back(pXonA); //if(abs(pXonA) < 1) std::cout<<"thisFragmentZ = "<<thisFragmentZ<<"\n";
-             pYonSideA.push_back(pYonA);
-             pZonSideA.push_back(pZonA);
-             pseudorapidity_A.push_back(eta_A);
-
-
-             if (thisFragmentZ == 0) {
-                 histoManager.GetHisto2(3)->Fill(pXonA, pYonA);
-                 histoManager.GetHisto(2)->Fill(pZonA);
-             } else if (thisFragmentZ == 1 && thisFragmentA == 1) {
-                 histoManager.GetHisto2(4)->Fill(pXonA, pYonA);
-                 histoManager.GetHisto(3)->Fill(pZonA);
-             } else if (thisFragmentZ < 20 && thisFragmentZ > 2) {
-                 histoManager.GetHisto2(5)->Fill(pXonA, pYonA);
-                 histoManager.GetHisto(4)->Fill(pZonA);
-             } else {
-                 histoManager.GetHisto2(6)->Fill(pXonA, pYonA);
-                 histoManager.GetHisto(5)->Fill(pZonA);
-             }
-         }
-
-
-         histoManager.GetHisto(6)->Fill(thisFragmentZ);
-         histoManager.GetHisto(7)->Fill(thisFragmentA);
-         histoManager.GetHisto2(2)->Fill(thisFragmentZ, thisFragmentA);
-         delete (*iVector);
-      }
-      //if(p4.mag() > 0.01) std::cout<<"p4.mag() = "<<p4.mag()<<" b = "<<b<<"\n";
-      delete theProduct;
+    if(histoManager.WritePseudorapidity()){
+        histoManager.GetTree()->Branch("pseudorapidity_on_A", "std::vector", &pseudorapidity_A);
+        histoManager.GetTree()->Branch("pseudorapidity_on_B", "std::vector", &pseudorapidity_B);
     }
+    if(histoManager.WriteMomentum()){
+        histoManager.GetTree()->Branch("pX_on_A", "std::vector" ,&pXonSideA,128000,1);
+        histoManager.GetTree()->Branch("pY_on_A", "std::vector" ,&pYonSideA,128000,1);
+        histoManager.GetTree()->Branch("pZ_on_A", "std::vector" ,&pZonSideA,128000,1);
+        histoManager.GetTree()->Branch("pX_on_B", "std::vector" ,&pXonSideB,128000,1);
+        histoManager.GetTree()->Branch("pY_on_B", "std::vector" ,&pYonSideB,128000,1);
+        histoManager.GetTree()->Branch("pZ_on_B", "std::vector" ,&pZonSideB,128000,1);
+    }
+
+    histoManager.GetTree()->Branch("impact_parameter", &b, "impact_parameter/f");
+
+    histoManager.GetTree()->Branch("PhiRotA", &PhiRotA, "PhiRotA/f");
+    histoManager.GetTree()->Branch("ThetaRotA", &ThetaRotA, "ThetaRotA/f");
+    histoManager.GetTree()->Branch("PhiRotB", &PhiRotB, "PhiRotB/f");
+    histoManager.GetTree()->Branch("ThetaRotB", &ThetaRotB, "ThetaRotB/f");
+    histoManager.GetTree()->Branch("Ecc", &Ecc, "Ecc[10]/f");
+
+    histoManager.GetTree()->Branch("Ex_En_per_nucleon", &ExEn, "Ex_En_per_nucleon/f");
+
+    histoManager.GetTreeFermiMom()->Branch("Fermi_momentum_x_side_A", &FermiMomA_x, "Fermi_momentumA_x/d");
+    histoManager.GetTreeFermiMom()->Branch("Fermi_momentum_y_side_A", &FermiMomA_y, "Fermi_momentumA_y/d");
+    histoManager.GetTreeFermiMom()->Branch("Fermi_momentum_x_side_B", &FermiMomB_x, "Fermi_momentumB_x/d");
+    histoManager.GetTreeFermiMom()->Branch("Fermi_momentum_y_side_B", &FermiMomB_y, "Fermi_momentumB_y/d");
+
+    //Get Z and A of nuclei
+    G4int sourceA = histoManager.GetInitialContidions().GetSourceA();
+    G4int sourceAb = histoManager.GetInitialContidions().GetSourceAb();
+    G4double rA_plus_rB = 1.3*(pow(G4double(sourceA),1./3.)+pow(G4double(sourceAb),1./3.));
+
+    //START OF THE MODELLING
+    //Setting up GMST
+    GMSTClustering* clusters = new GMSTClustering(histoManager.GetCriticalDistance(),sourceA,sourceAb);
+    clusters->SetCD(histoManager.GetCriticalDistance());
+
+    //Setting up ExcitationHandler
+    DeexcitationHandler* handlerNew = new DeexcitationHandler();
+    //handlerNew->SetMinEForMultiFrag(3*MeV);
+    handlerNew->SetMaxAandZForFermiBreakUp(19, 9);
+    handlerNew->SetMinExcitation(1e-4);
+    //Setting up Glauber code
+    histoManager.CalcXsectNN();
+    G4float omega = -1;
+    G4float signn = histoManager.GetXsectNN();
+    auto seed = static_cast<unsigned long int>(*CLHEP::HepRandom::getTheSeeds()); //setting the same seed to TGlauber
+
+    TGlauberMC *mcg=new TGlauberMC(histoManager.GetInitialContidions().GetSysA(),histoManager.GetInitialContidions().GetSysB(),signn,omega,seed);
+    mcg->SetMinDistance(0.4);
+    //mcg->SetNodeDistance(0);
+    mcg->SetCalcLength(0);
+    mcg->SetCalcArea(0);
+    mcg->SetCalcCore(0);
+    mcg->SetDetail(99);
+
+    if((histoManager.GetUpB() > 0 && histoManager.GetLowB() >= 0) && (histoManager.GetUpB() > histoManager.GetLowB()) && histoManager.GetUpB() < rA_plus_rB+7.5){
+        mcg->SetBmin(histoManager.GetLowB());
+        mcg->SetBmax(histoManager.GetUpB());
+    } 
+    else {std::cout << " \n------>Calculation will be MB \n"<<std::endl;}
+ 
+    //Setting Excitation Energy
+    ExcitationEnergy* ExEnA = new ExcitationEnergy(histoManager.GetStatType(), sourceA);
+    ExcitationEnergy* ExEnB = new ExcitationEnergy(histoManager.GetStatType(), sourceAb);
+
+    if(histoManager.GetStatType()> 2){
+        //Parameters for ALADIN parametrization
+        G4double e_0=11.5*MeV;//was 8.13 MeV
+        G4double sigma0 = 0.005; //was 0.01
+        G4double c0 = 2; // From Bondorf 1995
+        G4double sigmaE0 = 1*MeV;
+        G4double b0 = 0.1;
+        G4double Pe = 24*MeV;
+        G4double Pm = 0.2;
+        ExEnA->SetParametersALADIN(e_0,sigma0,c0);
+        ExEnB->SetParametersALADIN(e_0,sigma0,c0);
+        ExEnA->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
+        ExEnB->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
+        //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
+        //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
+    }
+
+    NucleonVector nV;
+    GlauberCollisionReader reader;
+    FermiMomentum FermiMom(&nV, "M");
+    FermiMom.SetPzPerNucleon(histoManager.GetInitialContidions().GetPzA()/ sourceA, histoManager.GetInitialContidions().GetPzB() / sourceAb);
+
+    for(G4int count=0;count<histoManager.GetIterations() ;count++){ 
+        id = count;
+        //An event generated by GlauberMC is here.
+        mcg->Run(1);
+
+        histoManager.CalcNucleonDensity(mcg->GetNucleons(), mcg->GetB());
+        //Side A $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+        TGlauNucleus *nucA   = mcg->GetNucleusA(); 
+        TGlauNucleus *nucB = mcg->GetNucleusB();
+        NpartA = mcg->GetNpartA(); 
+        NpartB = mcg->GetNpartB();
+        Npart = mcg->GetNpart();
+        b = mcg->GetB();
+        PhiRotA = nucA->GetPhiRot();
+        ThetaRotA = nucA->GetThetaRot();
+        PhiRotB = nucB->GetPhiRot();
+        ThetaRotB = nucB->GetThetaRot();
+        for(int k = 0; k<10; k++){Ecc[k] = mcg->GetEcc(k);}
+        Nhard = mcg->GetNhard();
+        Ncoll = mcg->GetNcoll();
+        Ncollpp = mcg->GetNcollpp();
+        Ncollpn = mcg->GetNcollpn();
+        Ncollnn = mcg->GetNcollnn();
+        TObjArray* nucleons=mcg->GetNucleons();
+
+        G4int A = 0;
+        G4int Z = 0;
+        G4int Ab = 0;
+        G4int Zb = 0;
+
+        reader.Read(nucleons);
+        nV = reader.GetNucleons();
+        Z = nV.GetZ("A"); A = nV.GetA("A"); Zb = nV.GetZ("B"); Ab = nV.GetA("B");
+
+        if(!(A == 0 && Ab ==0)){
+            G4int thisEventNumFragments = 0;
+            std::cout.setf(std::ios::scientific, std::ios::floatfield);
+            CLHEP::RandGauss randGauss(0, 1);
+
+            // Excitation energy is calculated only for unstable clusters
+            G4double energy_A = ExEnA->GetEnergy(A);
+            G4double energy_B = ExEnB->GetEnergy(Ab);
+            ExEn = energy_A/G4double(A);
+            histoManager.GetHisto2(1)->Fill(ExEn, G4double(A)/sourceA);
+
+            FermiMomA_x = FermiMom.GetBoost("A").getX();
+            FermiMomA_y = FermiMom.GetBoost("A").getY();
+            FermiMomB_x = FermiMom.GetBoost("B").getX();
+            FermiMomB_y = FermiMom.GetBoost("B").getY();
+
+            std::vector<G4FragmentVector> MstClustersVector = clusters->GetClusters(&nV, energy_A, energy_B, FermiMom.GetBoost("A"), FermiMom.GetBoost("B")); //d = const if energy is negative
+            G4FragmentVector clusters_to_excit_A = MstClustersVector.at(0);
+            G4FragmentVector clusters_to_excit_B = MstClustersVector.at(1);
+
+            d_MstA = clusters->GetCD("A");
+            d_MstB = clusters->GetCD("B");
+
+            histoManager.GetHisto2(7)->Fill(ExEn, d_MstA);
+
+            for(G4int i = 0; i < MstClustersVector.at(0).size(); ++i) {
+
+                G4Fragment aFragment = (*MstClustersVector.at(0).at(i));
+                G4LorentzVector p4 = aFragment.GetMomentum();
+                //if((aFragment.GetMomentum().m() - G4NucleiProperties::GetNuclearMass(aFragment.GetA(), aFragment.GetZ()) - ExEn*aFragment.GetA() !=0) && aFragment.GetA() != 1){std::cout<<"dE_x = "<<(aFragment.GetMomentum().m() - G4NucleiProperties::GetNuclearMass(aFragment.GetA(), aFragment.GetZ()))/aFragment.GetA() - ExEn<<"\n";}
+                A_cl.push_back(aFragment.GetA());
+                Z_cl.push_back(aFragment.GetZ());
+                G4double eta_A = 0;
+                //if(abs(p4.px()) < 1) std::cout<<G4double(clfrag_A)<<" "<<G4double(sourceA)<<"\n";
+
+                // TODO Devise the source of a differences between models
+                //    - Issues in propagation of Excitation energy through GMSTClustering
+                // HANDLER
+                G4ReactionProductVector *theProduct = handlerNew->BreakUp(aFragment);
+
+                thisEventNumFragments = theProduct->size();
+
+                histoManager.GetHisto(1)->Fill(thisEventNumFragments);
+
+                for (G4ReactionProductVector::iterator iVector = theProduct->begin(); iVector != theProduct->end(); ++iVector) {
+                    G4double thisFragmentZ = 0;
+                    G4double thisFragmentA = 0;
+
+                    const G4ParticleDefinition *pd = (*iVector)->GetDefinition();
+
+                    G4String particleEmitted = pd->GetParticleName();
+
+                    if (particleEmitted != "gamma" && particleEmitted != "e-" && particleEmitted != "e+") {
+                        thisFragmentZ = pd->GetAtomicNumber();
+                        thisFragmentA = pd->GetAtomicMass();
+                        if (pd->GetAtomicMass() == 0) { G4cout << "ERROR, pn = " << pd->GetParticleName() << G4endl;}
+                        MassOnSideA.push_back(thisFragmentA);
+                        ChargeOnSideA.push_back(thisFragmentZ);
+
+                        G4double eeA = (*iVector)->GetTotalEnergy();
+                        G4LorentzVector product_p4((*iVector)->GetMomentum().x(), (*iVector)->GetMomentum().y(),
+                        (*iVector)->GetMomentum().z(), eeA);
+                        G4double pXonA = product_p4.x() / MeV;
+                        G4double pYonA = product_p4.y() / MeV;
+                        G4double pZonA = product_p4.z() / MeV;
+                        p4 = p4 - product_p4;
+
+                        eta_A = 0.5 * log((std::sqrt(pXonA * pXonA + pYonA * pYonA + pZonA * pZonA) + pZonA) /
+                        (std::sqrt(pXonA * pXonA + pYonA * pYonA + pZonA * pZonA) - pZonA));
+
+                        pXonSideA.push_back(pXonA); //if(abs(pXonA) < 1) std::cout<<"thisFragmentZ = "<<thisFragmentZ<<"\n";
+                        pYonSideA.push_back(pYonA);
+                        pZonSideA.push_back(pZonA);
+                        pseudorapidity_A.push_back(eta_A);
+
+
+                        if (thisFragmentZ == 0) {
+                            histoManager.GetHisto2(3)->Fill(pXonA, pYonA);
+                            histoManager.GetHisto(2)->Fill(pZonA);
+                        } else if (thisFragmentZ == 1 && thisFragmentA == 1) {
+                            histoManager.GetHisto2(4)->Fill(pXonA, pYonA);
+                            histoManager.GetHisto(3)->Fill(pZonA);
+                        } else if (thisFragmentZ < 20 && thisFragmentZ > 2) {
+                            histoManager.GetHisto2(5)->Fill(pXonA, pYonA);
+                            histoManager.GetHisto(4)->Fill(pZonA);
+                        } else {
+                            histoManager.GetHisto2(6)->Fill(pXonA, pYonA);
+                            histoManager.GetHisto(5)->Fill(pZonA);
+                        }
+                    }
+
+
+                    histoManager.GetHisto(6)->Fill(thisFragmentZ);
+                    histoManager.GetHisto(7)->Fill(thisFragmentA);
+                    histoManager.GetHisto2(2)->Fill(thisFragmentZ, thisFragmentA);
+                    delete (*iVector);
+                }
+                //if(p4.mag() > 0.01) std::cout<<"p4.mag() = "<<p4.mag()<<" b = "<<b<<"\n";
+                delete theProduct;
+            }
+
+            ClustNumA = A_cl.size();
 
 //Side B $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-   for(G4int i = 0; i < MstClustersVector.at(1).size(); ++i) {
+            for(G4int i = 0; i < MstClustersVector.at(1).size(); ++i) {
+                G4Fragment aFragmentB = (*MstClustersVector.at(1).at(i));
+                G4LorentzVector p4b = aFragmentB.GetMomentum();
+                Ab_cl.push_back(aFragmentB.GetA());
+                Zb_cl.push_back(aFragmentB.GetZ());
+                G4double eta_B = 0;
 
-            G4Fragment aFragmentB = (*MstClustersVector.at(1).at(i));
-            G4LorentzVector p4b = aFragmentB.GetMomentum();
-            Ab_cl.push_back(aFragmentB.GetA());
-            Zb_cl.push_back(aFragmentB.GetZ());
-      G4double eta_B = 0;
+                // HANDLER
+                G4ReactionProductVector *theProductB = handlerNew->BreakUp(aFragmentB);
 
-      // HANDLER
-      G4ReactionProductVector *theProductB = handlerNew->BreakUp(aFragmentB);
+                for (G4ReactionProductVector::iterator kVector = theProductB->begin(); kVector != theProductB->end(); ++kVector) {
+                    G4int thisFragmentZb = 0;
+                    G4int thisFragmentAb = 0;
 
-      for (G4ReactionProductVector::iterator kVector = theProductB->begin(); kVector != theProductB->end(); ++kVector) {
-        G4int thisFragmentZb = 0;
-        G4int thisFragmentAb = 0;
+                    const G4ParticleDefinition *pdB = (*kVector)->GetDefinition();
 
-        const G4ParticleDefinition *pdB = (*kVector)->GetDefinition();
+                    G4String particleEmittedB = pdB->GetParticleName();
 
-        G4String particleEmittedB = pdB->GetParticleName();
+                    if (particleEmittedB != "gamma" && particleEmittedB != "e-" && particleEmittedB != "e+") {
+                        thisFragmentZb = pdB->GetAtomicNumber();
+                        thisFragmentAb = pdB->GetAtomicMass();
+                        MassOnSideB.push_back(thisFragmentAb);
+                        ChargeOnSideB.push_back(thisFragmentZb);
 
-        if (particleEmittedB != "gamma" && particleEmittedB != "e-" && particleEmittedB != "e+") {
-          thisFragmentZb = pdB->GetAtomicNumber();
-          thisFragmentAb = pdB->GetAtomicMass();
-          MassOnSideB.push_back(thisFragmentAb);
-          ChargeOnSideB.push_back(thisFragmentZb);
+                        G4double eeB = (*kVector)->GetTotalEnergy();
+                        G4LorentzVector product_p4b((*kVector)->GetMomentum().x(), (*kVector)->GetMomentum().y(), (*kVector)->GetMomentum().z(), eeB);
+                        G4double pXonB = product_p4b.x() / MeV;
+                        G4double pYonB = product_p4b.y() / MeV;
+                        G4double pZonB = product_p4b.z() / MeV;
+                        p4b = p4b - product_p4b;
 
-          G4double eeB = (*kVector)->GetTotalEnergy();
-          G4LorentzVector product_p4b((*kVector)->GetMomentum().x(), (*kVector)->GetMomentum().y(),
-                                     (*kVector)->GetMomentum().z(), eeB);
-          G4double pXonB = product_p4b.x() / MeV;
-          G4double pYonB = product_p4b.y() / MeV;
-          G4double pZonB = product_p4b.z() / MeV;
-          p4b = p4b - product_p4b;
+                        eta_B = 0.5 * log((std::sqrt(pXonB * pXonB + pYonB * pYonB + pZonB * pZonB) + pZonB) /
+                        (std::sqrt(pXonB * pXonB + pYonB * pYonB + pZonB * pZonB) - pZonB));
+                        pXonSideB.push_back(pXonB);
+                        pYonSideB.push_back(pYonB);
+                        pZonSideB.push_back(pZonB);
+                        pseudorapidity_B.push_back(eta_B);
+                    }
+                    histoManager.GetHisto(0)->Fill(thisFragmentZb);
+                    delete (*kVector);
+                }
+                delete theProductB;
+            }
 
-          eta_B = 0.5 * log((std::sqrt(pXonB * pXonB + pYonB * pYonB + pZonB * pZonB) + pZonB) /
-                           (std::sqrt(pXonB * pXonB + pYonB * pYonB + pZonB * pZonB) - pZonB));
-          pXonSideB.push_back(pXonB);
-          pYonSideB.push_back(pYonB);
-          pZonSideB.push_back(pZonB);
-          pseudorapidity_B.push_back(eta_B);
+            ClustNumB = Ab_cl.size();
 
-          }
-        histoManager.GetHisto(0)->Fill(thisFragmentZb);
-        delete (*kVector);
-      }
-      delete theProductB;
+            //Filling histo-s + cleaning
+            histoManager.GetTreeMST()->Fill();
+            histoManager.GetTreeFermiMom()->Fill();
+            A_cl.clear();
+            Z_cl.clear();
+            Ab_cl.clear();
+            Zb_cl.clear();
+
+            histoManager.GetTree()->Fill();
+            MassOnSideA.clear();
+            MassOnSideB.clear();
+            ChargeOnSideB.clear();
+            ChargeOnSideA.clear();
+            pXonSideA.clear();
+            pXonSideB.clear();
+            pYonSideA.clear();
+            pYonSideB.clear();
+            pZonSideA.clear();
+            pZonSideB.clear();
+            pseudorapidity_A.clear();
+            pseudorapidity_B.clear();
+
+            // Events calc info update
+            if (!G4bool(count % 100)) { G4cout << "Program is working," << count << " events calculated    \r" << std::flush; }
+
+        }
     }
 
-   histoManager.GetTreeMST()->Fill();
-   A_cl.clear();
-   Z_cl.clear();
-   Ab_cl.clear();
-   Zb_cl.clear();
-
-    //Filling histo-s + cleaning
-    histoManager.GetTree()->Fill();
-    MassOnSideA.clear();
-    MassOnSideB.clear();
-    ChargeOnSideB.clear();
-    ChargeOnSideA.clear();
-    pXonSideA.clear();
-    pXonSideB.clear();
-    pYonSideA.clear();
-    pYonSideB.clear();
-    pZonSideA.clear();
-    pZonSideB.clear();
-    pseudorapidity_A.clear();
-    pseudorapidity_B.clear();
-
-    // Events calc info update
-    if (!G4bool(count % 100)) { G4cout << "Program is working," << count << " events calculated    \r" << std::flush; }
-
+    G4cout<<"----> collided "<<histoManager.GetIterations()<<" nuclei "<<histoManager.GetSysA()<< " with " << histoManager.GetSysB() <<" at N-N x-section "<<signn<<" mb"<<G4endl;
+    if(!histoManager.ToFileOrNot()){
+        G4cout<<"----> total x-sect = "<<mcg->GetTotXSect()<< " +- " << mcg->GetTotXSectErr() <<" b";
+        histoManager.FillConditionsTree(mcg->GetTotXSect());
     }
-  }
+    else
+    {
+        G4cout<<"----> Only 1 event, no tot x-sect";
+    }
+    histoManager.CleanHisto();
 
-G4cout<<"----> collided "<<histoManager.GetIterations()<<" nuclei "<<histoManager.GetSysA()<< " with " << histoManager.GetSysB() <<" at N-N x-section "<<signn<<" mb"<<G4endl;
-if(!histoManager.ToFileOrNot()){
-  G4cout<<"----> total x-sect = "<<mcg->GetTotXSect()<< " +- " << mcg->GetTotXSectErr() <<" b";
-  histoManager.FillConditionsTree(mcg->GetTotXSect());
-}
-else
-{
-  G4cout<<"----> Only 1 event, no tot x-sect";
-}
-histoManager.CleanHisto();
-
-delete runManager;
-delete clusters;
-delete handlerNew;
-delete mcg;
-delete ExEnA;
-delete ExEnB;
-return 0;
+    delete runManager;
+    delete clusters;
+    delete handlerNew;
+    delete mcg;
+    delete ExEnA;
+    delete ExEnB;
+    return 0;
 }

--- a/Multifragmentation/include/G4Solver.hh
+++ b/Multifragmentation/include/G4Solver.hh
@@ -1,0 +1,112 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4Solver_h
+#define G4Solver_h 1
+
+#include "globals.hh"
+
+#include <cmath>
+
+#define DefaultTolerance 5.0e-14
+
+template <class Function> class G4Solver 
+{
+public:
+    enum {DefaultMaxIter = 100};
+	
+    // default constructor
+    G4Solver() : MaxIter(DefaultMaxIter), tolerance(DefaultTolerance),
+		 a(0.0), b(0.0), root(0.0) {};
+	
+    G4Solver(const G4int iterations, const G4double tol) :
+	MaxIter(iterations), tolerance(tol),
+	a(0.0), b(0.0), root(0.0) {};
+
+    // copy constructor	
+    G4Solver(const G4Solver & right);
+
+    // destructor
+    ~G4Solver() {};
+	
+    // operators
+    G4Solver & operator=(const G4Solver & right);
+    G4bool operator==(const G4Solver & right) const;
+    G4bool operator!=(const G4Solver & right) const;
+		
+    G4int GetMaxIterations(void) const {return MaxIter;}
+    void SetMaxIterations(const G4int iterations) {MaxIter=iterations;}
+	
+    G4double GetTolerance(void) const {return tolerance;}
+    void SetTolerance(const G4double epsilon) {tolerance = epsilon;}
+	
+	
+    G4double GetIntervalLowerLimit(void) const {return a;}
+    G4double GetIntervalUpperLimit(void) const {return b;}
+	
+    void SetIntervalLimits(const G4double Limit1, const G4double Limit2);
+    
+    G4double GetRoot(void) const {return root;}
+    
+    // Calculates the root by the Bisection method
+    G4bool Bisection(Function & theFunction);	
+	
+    // Calculates the root by the Regula-Falsi method
+    G4bool RegulaFalsi(Function & theFunction);
+	
+	
+    // Calculates the root by the Brent's method
+    G4bool Brent(Function & theFunction);
+
+    // Calculates the root by the Inverse Parabolic Interpolation method 
+    // due to Jack Crenshaw
+    G4bool Crenshaw(Function & theFunction);
+	
+private:
+
+    // Maximum number of iterations
+    G4int MaxIter;
+
+    // 
+    G4double tolerance;
+
+    // interval limits [a,b] which should bracket the root
+    G4double a;
+    G4double b;
+
+    // The root
+    G4double root;
+
+};
+
+#include "G4Solver.icc"
+
+#endif

--- a/Multifragmentation/include/G4Solver.icc
+++ b/Multifragmentation/include/G4Solver.icc
@@ -1,0 +1,352 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+template <class Function>
+G4bool G4Solver<Function>::Bisection(Function & theFunction)
+{
+    // Check the interval before start
+    if (a > b || std::abs(a-b) <= tolerance) 
+    {
+	G4cerr << "G4Solver::Bisection: The interval must be properly set." << G4endl;
+	return false;
+    }
+    G4double fa = theFunction(a);
+    G4double fb = theFunction(b);
+    if (fa*fb > 0.0) 
+    {
+	G4cerr << "G4Solver::Bisection: The interval must include a root." << G4endl;
+	return false;
+    }
+    
+    G4double eps=tolerance*(b-a);
+    
+    
+    // Finding the root
+    for (G4int i = 0; i < MaxIter; i++) 
+    {
+	G4double c = (a+b)/2.0;
+	if ((b-a) < eps) 
+	{
+	    root = c;
+	    return true;
+	}
+	G4double fc = theFunction(c);
+	if (fc == 0.0) 
+	{
+	    root = c;
+	    return true;
+	}
+	if (fa*fc < 0.0) 
+	{
+	    a=c;
+	    fa=fc;
+	} 
+	else 
+	{
+	    b=c;
+	    fb=fc;
+	}
+    }
+    G4cerr << "G4Solver::Bisection: Excedded maximum number of iterations whithout convegence." << G4endl;
+    return false;
+}
+
+
+template <class Function>
+G4bool G4Solver<Function>::RegulaFalsi(Function & theFunction)
+{
+    // Check the interval before start
+    if (a > b || std::abs(a-b) <= tolerance) 
+    {
+	G4cerr << "G4Solver::RegulaFalsi: The interval must be properly set." << G4endl;
+	return false;
+    }
+    G4double fa = theFunction(a);
+    G4double fb = theFunction(b);
+    if (fa*fb > 0.0) 
+    {
+	G4cerr << "G4Solver::RegulaFalsi: The interval must include a root." << G4endl;
+	return false;
+    }
+    
+    G4double eps=tolerance*(b-a);
+	
+	
+    // Finding the root
+    for (G4int i = 0; i < MaxIter; i++) 
+    {
+	G4double c = (a*fb-b*fa)/(fb-fa);
+	G4double delta = std::min(std::abs(c-a),std::abs(b-c));
+	if (delta < eps) 
+	{
+	    root = c;
+	    return true;
+	}
+	G4double fc = theFunction(c);
+	if (fc == 0.0) 
+	{
+	    root = c;
+	    return true;
+	}
+	if (fa*fc < 0.0) 
+	{
+	    b=c;
+	    fb=fc;
+	} 
+	else 
+	{
+	    a=c;
+	    fa=fc;
+	}
+    }
+    G4cerr << "G4Solver::Bisection: Excedded maximum number of iterations whithout convegence." << G4endl;
+    return false;
+
+}	
+
+template <class Function>
+G4bool G4Solver<Function>::Brent(Function & theFunction)
+{
+    
+    const G4double precision = 3.0e-8;
+    
+    // Check the interval before start
+    if (a > b || std::abs(a-b) <= tolerance) 
+    {
+	G4cerr << "G4Solver::Brent: The interval must be properly set." << G4endl;
+	return false;
+    }
+    G4double fa = theFunction(a);
+    G4double fb = theFunction(b);
+    if (fa*fb > 0.0) 
+    {
+	G4cerr << "G4Solver::Brent: The interval must include a root." << G4endl;
+	return false;
+    }
+    
+    G4double c = b;
+    G4double fc = fb;
+    G4double d = 0.0;
+    G4double e = 0.0;
+    
+    for (G4int i=0; i < MaxIter; i++) 
+    {
+	// Rename a,b,c and adjust bounding interval d
+	if (fb*fc > 0.0) 
+	{
+	    c = a;
+	    fc = fa;
+	    d = b - a;
+	    e = d;
+	}
+	if (std::abs(fc) < std::abs(fb)) 
+	{
+	    a = b;
+	    b = c;
+	    c = a;
+	    fa = fb;
+	    fb = fc;
+	    fc = fa;
+	}
+	G4double Tol1 = 2.0*precision*std::abs(b) + 0.5*tolerance;
+	G4double xm = 0.5*(c-b);
+	if (std::abs(xm) <= Tol1 || fb == 0.0) 
+	{
+	    root = b;
+	    return true;
+	}
+	// Inverse quadratic interpolation
+	if (std::abs(e) >= Tol1 && std::abs(fa) > std::abs(fb)) 
+	{
+	    G4double ss = fb/fa;
+	    G4double p = 0.0;
+	    G4double q = 0.0;
+	    if (a == c) 
+	    {
+		p = 2.0*xm*ss;
+		q = 1.0 - ss;
+	    } 
+	    else 
+	    {
+		q = fa/fc;
+		G4double r = fb/fc;
+		p = ss*(2.0*xm*q*(q-r)-(b-a)*(r-1.0));
+		q = (q-1.0)*(r-1.0)*(ss-1.0);
+	    }
+	    // Check bounds
+	    if (p > 0.0) q = -q;
+	    p = std::abs(p);
+	    G4double min1 = 3.0*xm*q-std::abs(Tol1*q);
+	    G4double min2 = std::abs(e*q);
+	    if (2.0*p < std::min(min1,min2)) 
+	    {
+		// Interpolation
+		e = d;
+		d = p/q;
+	    } 
+	    else 
+	    {
+		// Bisection
+		d = xm;
+		e = d;
+	    }
+	} 
+	else 
+	{
+	    // Bounds decreasing too slowly, use bisection
+	    d = xm;
+	    e = d;
+	}
+	// Move last guess to a 
+	a = b;
+	fa = fb;
+	if (std::abs(d) > Tol1) b += d;
+	else 
+	{
+	    if (xm >= 0.0) b += std::abs(Tol1);
+	    else b -= std::abs(Tol1);
+	}
+	fb = theFunction(b);
+    }
+    G4cerr << "G4Solver::Brent: Number of iterations exceeded." << G4endl;
+    return false;
+}
+
+
+
+template <class Function>
+G4bool G4Solver<Function>::Crenshaw(Function & theFunction)
+{
+    // Check the interval before start
+    if (a > b || std::abs(a-b) <= tolerance) 
+    {
+	G4cerr << "G4Solver::Crenshaw: The interval must be properly set." << G4endl;
+	return false;
+    }
+
+    G4double fa = theFunction(a);
+    if (fa == 0.0) 
+    {
+	root = a;
+	return true;
+    }
+
+    G4double Mlast = a;
+
+    G4double fb = theFunction(b);
+    if (fb == 0.0)
+    {
+	root = b;
+	return true;
+    }
+
+    if (fa*fb > 0.0) 
+    {
+	G4cerr << "G4Solver::Crenshaw: The interval must include a root." << G4endl;
+	return false;
+    }
+
+    
+    for (G4int i=0; i < MaxIter; i++) 
+      {
+	G4double c = 0.5 * (b + a);
+	G4double fc = theFunction(c);
+	if (fc == 0.0 || std::abs(c - a) < tolerance) 
+	  {
+	    root = c;
+	    return true;
+	  }
+
+	if (fc * fa  > 0.0)
+	  {
+	    G4double tmp = a;
+	    a = b;
+	    b = tmp;
+	    tmp = fa;
+	    fa = fb;
+	    fb = tmp;
+	  }
+	
+	G4double fc0 = fc - fa;
+	G4double fb1 = fb - fc;
+	G4double fb0 = fb - fa;
+	if (fb * fb0 < 2.0 * fc * fc0)
+	  {
+	    b = c;
+	    fb = fc;
+	  }
+	else 
+	  {
+	    G4double B = (c - a) / fc0;
+	    G4double C = (fc0 - fb1) / (fb1 * fb0);
+	    G4double M = a - B * fa * (1.0 - C * fc);
+	    G4double fM = theFunction(M);
+	    if (fM == 0.0 || std::abs(M - Mlast) < tolerance)
+	      {
+		root = M;
+		return true;
+	      }
+	    Mlast = M;
+	    if (fM * fa < 0.0)
+	      {
+		b = M;
+		fb = fM;
+	      }
+	    else 
+	    {
+		a = M;
+		fa = fM;
+		b = c;
+		fb = fc;
+	    }
+	}
+    }
+    return false;
+}
+
+
+
+
+template <class Function> 	
+void G4Solver<Function>::SetIntervalLimits(const G4double Limit1, const G4double Limit2)
+{
+    if (std::abs(Limit1-Limit2) <= tolerance) 
+    {
+	G4cerr << "G4Solver::SetIntervalLimits: Interval must be wider than tolerance." << G4endl;
+	return;
+    }
+    if (Limit1 < Limit2) 
+    {
+	a = Limit1;
+	b = Limit2;
+    } 
+    else 
+    {
+	a = Limit2;
+	b = Limit1;
+    }
+    return;
+}
+

--- a/Multifragmentation/include/G4StatMF.hh
+++ b/Multifragmentation/include/G4StatMF.hh
@@ -1,0 +1,101 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#ifndef G4StatMF_h
+#define G4StatMF_h 1
+
+#include "globals.hh"
+#include "G4VMultiFragmentation.hh"
+#include "G4VStatMFEnsemble.hh"
+#include "G4StatMFMicroCanonical.hh"
+#include "G4StatMFMacroCanonical.hh"
+#include "G4StatMFChannel.hh"
+#include "G4Fragment.hh"
+#include "G4ParticleTable.hh"
+#include "G4IonTable.hh"
+#include "Randomize.hh"
+
+class G4StatMF : public G4VMultiFragmentation
+{
+public:
+    // Default constructor
+    G4StatMF();
+    // Destructor
+    ~G4StatMF();
+
+private:
+    // Copy constructor	
+    G4StatMF(const G4StatMF & right);
+
+    // Operators
+    G4StatMF & operator=(const G4StatMF & right);
+    G4bool operator==(const G4StatMF & right);
+    G4bool operator!=(const G4StatMF & right);
+
+public:
+
+    G4FragmentVector * BreakItUp(const G4Fragment &theNucleus);
+
+private:
+
+    // This finds temperature of breaking channel.
+    G4bool FindTemperatureOfBreakingChannel(const G4Fragment & theFragment, 
+					    const G4StatMFChannel * aChannel,
+					    G4double & Temperature);
+
+    // 
+    G4double CalcEnergy(G4int A, G4int Z, 
+			const G4StatMFChannel * aChannel,
+			G4double T);
+
+
+private:
+
+    G4VStatMFEnsemble * _theEnsemble;
+
+
+
+};
+
+#endif
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Multifragmentation/include/G4StatMFChannel.hh
+++ b/Multifragmentation/include/G4StatMFChannel.hh
@@ -1,0 +1,120 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFChannel_h
+#define G4StatMFChannel_h 1
+
+#include <deque>
+
+#include "G4StatMFParameters.hh"
+#include "G4StatMFFragment.hh"
+
+
+class G4StatMFChannel {
+
+public:
+    // Default Constructor
+    G4StatMFChannel();
+
+    // Destructor
+    ~G4StatMFChannel();
+
+private:
+
+    // Copy constructor
+    G4StatMFChannel(const G4StatMFChannel & right);
+
+    // operators
+    G4StatMFChannel & operator=(const G4StatMFChannel & right);
+
+    G4bool operator==(const G4StatMFChannel & right) const;
+    G4bool operator!=(const G4StatMFChannel & right) const;
+	
+public:
+
+    void CreateFragment(G4int A, G4int Z);
+	
+    inline size_t GetMultiplicity(void) { return _theFragments.size();}
+	
+    // Return false if there is some unphysical fragment
+    G4bool CheckFragments(void);
+
+    G4double GetFragmentsCoulombEnergy(void);
+
+    G4double GetFragmentsEnergy(G4double T) const;
+	
+    G4FragmentVector * GetFragments(G4int anA, G4int anZ, G4double T);
+	
+private:
+
+    // This method calculates asymptotic fragments momenta.
+    void CoulombImpulse(G4int anA, G4int anZ, G4double T);
+	
+    void PlaceFragments(G4int anA);
+
+    void SolveEqOfMotion(G4int anA, G4int anZ, G4double T);
+
+    // Calculates fragments momentum components at the breakup instant.
+    // Fragment kinetic energies will be calculated according to the
+    // Boltzamann distribution at given temperature.
+    void FragmentsMomenta(G4int NF, G4int idx, G4double T);	
+
+    // Rotates a 3-vector P to close momentum triangle Pa + V + P = 0
+    G4ThreeVector RotateMomentum(G4ThreeVector Pa, G4ThreeVector V, 
+				 G4ThreeVector P);
+
+private:
+
+    std::deque<G4StatMFFragment*> _theFragments;
+
+    G4int _NumOfNeutralFragments;
+	
+    G4int _NumOfChargedFragments;
+
+  struct DeleteFragment 
+  {
+    template<typename T>
+    void operator()(const T* ptr) const
+    {
+      delete ptr;
+    }
+  };
+
+};
+
+#endif
+
+
+
+
+
+
+

--- a/Multifragmentation/include/G4StatMFFragment.hh
+++ b/Multifragmentation/include/G4StatMFFragment.hh
@@ -1,0 +1,112 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFFragment_h
+#define G4StatMFFragment_h 1
+
+#include "G4StatMFParameters.hh"
+#include "G4ThreeVector.hh"
+#include "G4ParticleTable.hh"
+#include "G4IonTable.hh"
+#include "G4Fragment.hh"
+
+class G4StatMFFragment {
+
+public:
+    // Constructor
+    G4StatMFFragment(G4int anA, G4int aZ) :
+	theA(anA),theZ(aZ),
+	_position(0.0,0.0,0.0),
+	_momentum(0.0,0.0,0.0)
+	{}
+
+
+    // Destructor
+    virtual ~G4StatMFFragment() {};
+
+
+private:
+    // Default constructor
+    G4StatMFFragment(){};
+	
+    // Copy constructor
+    G4StatMFFragment(const G4StatMFFragment & right);
+
+    // operators
+    G4StatMFFragment & operator=(const G4StatMFFragment & right);
+public:
+    G4bool operator==(const G4StatMFFragment & right) const;
+    G4bool operator!=(const G4StatMFFragment & right) const;
+	
+public:
+
+    G4double GetCoulombEnergy(void) const;
+	
+    G4double GetEnergy(const G4double T) const;
+	
+    G4double GetInvLevelDensity(void) const;
+
+    G4int GetA(void) const {return theA;}
+	
+    G4int GetZ(void) const {return theZ;}
+	
+    void SetPosition(const G4ThreeVector& aPosition) {_position = aPosition;}
+	
+    G4ThreeVector& GetPosition(void) {return _position;}
+	
+    void SetMomentum(const G4ThreeVector& aMomentum) {_momentum = aMomentum;}
+
+    G4ThreeVector& GetMomentum(void) {return _momentum;}
+
+    G4Fragment * GetFragment(const G4double T);
+	
+    G4double GetNuclearMass(void)
+	{return G4ParticleTable::GetParticleTable()->GetIonTable()
+	                       ->GetIonMass(theZ, theA);}
+	
+
+private:
+
+    G4double CalcExcitationEnergy(const G4double T);
+
+private:
+
+    G4int theA;
+	
+    G4int theZ;
+	
+    G4ThreeVector _position;
+	
+    G4ThreeVector _momentum;
+};
+
+#endif
+

--- a/Multifragmentation/include/G4StatMFMacroBiNucleon.hh
+++ b/Multifragmentation/include/G4StatMFMacroBiNucleon.hh
@@ -1,0 +1,73 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroBiNucleon_h_h
+#define G4StatMFMacroBiNucleon_h 1
+
+#include "G4VStatMFMacroCluster.hh"
+#include "G4NucleiProperties.hh"
+
+class G4StatMFMacroBiNucleon : public G4VStatMFMacroCluster {
+
+public:
+
+    // Default constructor
+    G4StatMFMacroBiNucleon() : G4VStatMFMacroCluster(2) {};
+
+    // Destructor
+    ~G4StatMFMacroBiNucleon() {};
+	
+
+private:
+
+    // Copy constructor
+    G4StatMFMacroBiNucleon(const G4StatMFMacroBiNucleon & right);
+
+    // operators
+    G4StatMFMacroBiNucleon & operator=(const G4StatMFMacroBiNucleon & right);
+    G4bool operator==(const G4StatMFMacroBiNucleon & right) const;
+    G4bool operator!=(const G4StatMFMacroBiNucleon & right) const;
+
+public:
+
+    G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+				  const G4double nu, const G4double T);
+					
+					
+					
+    G4double CalcZARatio(const G4double ) {return theZARatio = 0.5;}
+	
+    G4double CalcEnergy(const G4double T);
+	
+    G4double CalcEntropy(const G4double T, const G4double FreeVol);
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMacroCanonical.hh
+++ b/Multifragmentation/include/G4StatMFMacroCanonical.hh
@@ -1,0 +1,122 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroCanonical_h
+#define G4StatMFMacroCanonical_h 1
+
+#include "G4Fragment.hh"
+#include "G4StatMFFragment.hh"
+#include "G4VStatMFEnsemble.hh"
+#include "G4VStatMFMacroCluster.hh"
+#include "G4StatMFMacroNucleon.hh"
+#include "G4StatMFMacroBiNucleon.hh"
+#include "G4StatMFMacroTriNucleon.hh"
+#include "G4StatMFMacroTetraNucleon.hh"
+#include "G4StatMFMacroMultiNucleon.hh"
+#include "G4StatMFParameters.hh"
+#include "G4StatMFChannel.hh"
+#include "G4StatMFMacroTemperature.hh"
+#include "Randomize.hh"
+
+
+class G4StatMFMacroCanonical : public G4VStatMFEnsemble {
+
+public:
+
+    // G4StatMFMacroCanonical class must be initialized with a G4Fragment.
+    G4StatMFMacroCanonical(G4Fragment const & theFragment);
+
+    // destructor
+    ~G4StatMFMacroCanonical();
+
+private:
+    // default constructor
+    G4StatMFMacroCanonical() {};
+
+
+    // copy constructor
+    G4StatMFMacroCanonical(const G4StatMFMacroCanonical &) : G4VStatMFEnsemble() {};
+
+
+    // operators
+    G4StatMFMacroCanonical & operator=(const G4StatMFMacroCanonical & right);
+    G4bool operator==(const G4StatMFMacroCanonical & right) const;
+    G4bool operator!=(const G4StatMFMacroCanonical & right) const;
+
+
+public:
+
+    // Choice of fragment atomic numbers and charges.
+    G4StatMFChannel * ChooseAandZ(const G4Fragment &theFragment);
+
+private:
+
+    // Initailization method
+    void Initialize(const G4Fragment & theFragment);
+
+    //
+    void CalculateTemperature(const G4Fragment & theFragment);
+
+    // Determines fragments multiplicities and compute total fragment multiplicity
+    G4double ChooseA(G4int A, std::vector<G4int> & ANumbers);
+	
+    // Samples charges of fragments
+    G4StatMFChannel * ChooseZ(G4int & Z, 
+			      std::vector<G4int> & FragmentsA);
+
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+
+    // Chemical Potential \mu
+    G4double _ChemPotentialMu;
+
+    // Chemical Potential \nu
+    G4double _ChemPotentialNu;
+
+
+    // Parameter Kappa
+    G4double _Kappa;
+
+    // Clusters
+    std::vector<G4VStatMFMacroCluster*> _theClusters;
+
+  struct DeleteFragment 
+  {
+    template<typename T>
+    void operator()(const T* ptr) const
+    {
+      delete ptr;
+    }
+  };
+  
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMacroChemicalPotential.hh
+++ b/Multifragmentation/include/G4StatMFMacroChemicalPotential.hh
@@ -1,0 +1,116 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroChemicalPotential_h
+#define G4StatMFMacroChemicalPotential_h 1
+
+#include <vector>
+
+#include "G4StatMFParameters.hh"
+#include "G4VStatMFMacroCluster.hh"
+#include "G4StatMFMacroMultiplicity.hh"
+#include "G4Solver.hh"
+
+
+
+class G4StatMFMacroChemicalPotential {
+
+public:
+
+    G4StatMFMacroChemicalPotential(const G4double anA, const G4double aZ,
+				   const G4double kappa, 
+				   const G4double temp, 
+				   std::vector<G4VStatMFMacroCluster*> * ClusterVector) :
+	theA(anA),
+	theZ(aZ),
+	_Kappa(kappa),
+	_MeanMultiplicity(0.0),
+	_MeanTemperature(temp),
+	_ChemPotentialMu(0.0),
+	_ChemPotentialNu(0.0),
+	_theClusters(ClusterVector) 
+	{};
+	
+    ~G4StatMFMacroChemicalPotential() {};
+   
+    G4double operator()(const G4double nu)
+	{ return (theZ - this->CalcMeanZ(nu))/theZ; }	
+
+private:
+    // Default constructor
+    G4StatMFMacroChemicalPotential() {};
+
+    // copy constructor
+    G4StatMFMacroChemicalPotential(const G4StatMFMacroChemicalPotential &) {};
+
+
+    // operators
+    G4StatMFMacroChemicalPotential & operator=(const G4StatMFMacroChemicalPotential & right);
+    G4bool operator==(const G4StatMFMacroChemicalPotential & right) const;
+    G4bool operator!=(const G4StatMFMacroChemicalPotential & right) const;
+
+public:
+
+    G4double GetMeanMultiplicity(void) const {return _MeanMultiplicity;}
+	
+    G4double GetChemicalPotentialMu(void) const {return _ChemPotentialMu;}
+
+    G4double GetChemicalPotentialNu(void) const {return _ChemPotentialNu;}
+
+    G4double CalcChemicalPotentialNu(void);
+
+private:
+	
+    G4double CalcMeanZ(const G4double nu);
+
+    void CalcChemicalPotentialMu(const G4double nu);
+
+private:
+
+    G4double theA;
+
+    G4double theZ;
+
+    G4double _Kappa;
+
+    G4double _MeanMultiplicity;
+
+    G4double _MeanTemperature;
+	
+    G4double _ChemPotentialMu;
+	
+    G4double _ChemPotentialNu;
+	
+    std::vector<G4VStatMFMacroCluster*> * _theClusters; 
+
+
+};
+#endif

--- a/Multifragmentation/include/G4StatMFMacroMultiNucleon.hh
+++ b/Multifragmentation/include/G4StatMFMacroMultiNucleon.hh
@@ -1,0 +1,75 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroMultiNucleon_h
+#define G4StatMFMacroMultiNucleon_h 1
+
+#include "G4VStatMFMacroCluster.hh"
+
+
+class G4StatMFMacroMultiNucleon : public G4VStatMFMacroCluster {
+
+public:
+
+    // Constructor
+    G4StatMFMacroMultiNucleon(const G4int Size) : G4VStatMFMacroCluster(Size) {};
+
+    // Destructor
+    ~G4StatMFMacroMultiNucleon() {};
+	
+
+private:
+
+    // Default constructor
+    G4StatMFMacroMultiNucleon();
+	
+    // Copy constructor
+    G4StatMFMacroMultiNucleon(const G4StatMFMacroMultiNucleon & right);
+
+    // operators
+    G4StatMFMacroMultiNucleon & operator=(const G4StatMFMacroMultiNucleon & right);
+    G4bool operator==(const G4StatMFMacroMultiNucleon & right) const;
+    G4bool operator!=(const G4StatMFMacroMultiNucleon & right) const;
+
+public:
+
+    G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+				  const G4double nu, const G4double T);
+								
+    G4double CalcZARatio(const G4double nu); 
+	
+    G4double CalcEnergy(const G4double T);
+
+    G4double CalcEntropy(const G4double T, const G4double FreeVol);
+	
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMacroMultiplicity.hh
+++ b/Multifragmentation/include/G4StatMFMacroMultiplicity.hh
@@ -1,0 +1,109 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroMultiplicity_h
+#define G4StatMFMacroMultiplicity_h 1
+
+#include <vector>
+
+#include "G4StatMFParameters.hh"
+#include "G4VStatMFMacroCluster.hh"
+#include "G4Solver.hh"
+
+
+
+class G4StatMFMacroMultiplicity {
+
+public:
+
+    G4StatMFMacroMultiplicity(const G4double anA, 
+			      const G4double kappa, 
+			      const G4double temp, 
+			      const G4double nu,
+			      std::vector<G4VStatMFMacroCluster*> * ClusterVector) :
+	theA(anA),
+	_Kappa(kappa),
+	_MeanMultiplicity(0.0),
+	_MeanTemperature(temp),
+	_ChemPotentialMu(0.0),
+	_ChemPotentialNu(nu),
+	_theClusters(ClusterVector) 
+	{};
+	
+    ~G4StatMFMacroMultiplicity() {};
+   
+    G4double operator()(const G4double mu)
+	{ return (theA - this->CalcMeanA(mu))/theA; }	
+
+private:
+    // Default constructor
+    G4StatMFMacroMultiplicity() {};
+
+    // copy constructor
+    G4StatMFMacroMultiplicity(const G4StatMFMacroMultiplicity &) {};
+
+
+    // operators
+    G4StatMFMacroMultiplicity & operator=(const G4StatMFMacroMultiplicity & right);
+    G4bool operator==(const G4StatMFMacroMultiplicity & right) const;
+    G4bool operator!=(const G4StatMFMacroMultiplicity & right) const;
+
+public:
+
+    G4double GetMeanMultiplicity(void) const {return _MeanMultiplicity;}
+	
+    G4double GetChemicalPotentialMu(void) const {return _ChemPotentialMu;}
+
+    G4double CalcChemicalPotentialMu(void);
+
+private:
+	
+    G4double CalcMeanA(const G4double mu);
+
+private:
+
+    G4double theA;
+
+    G4double _Kappa;
+
+    G4double _MeanMultiplicity;
+
+    G4double _MeanTemperature;
+	
+    G4double _ChemPotentialMu;
+	
+    G4double _ChemPotentialNu;
+	
+    std::vector<G4VStatMFMacroCluster*> * _theClusters; 
+
+
+};
+#endif

--- a/Multifragmentation/include/G4StatMFMacroNucleon.hh
+++ b/Multifragmentation/include/G4StatMFMacroNucleon.hh
@@ -1,0 +1,77 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroNucleon_h
+#define G4StatMFMacroNucleon_h 1
+
+#include "G4VStatMFMacroCluster.hh"
+
+
+class G4StatMFMacroNucleon : public G4VStatMFMacroCluster {
+
+public:
+
+  G4StatMFMacroNucleon(); 
+
+  ~G4StatMFMacroNucleon();
+	
+  G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+				const G4double nu, const G4double T);
+	
+  inline G4double CalcZARatio(const G4double ) 
+  { 
+    theZARatio = 0.0;
+    if (_ProtonMeanMultiplicity+_NeutronMeanMultiplicity > 0.0) {
+      theZARatio = _ProtonMeanMultiplicity/
+	(_ProtonMeanMultiplicity+_NeutronMeanMultiplicity);
+    }
+    return theZARatio; 
+  }					
+						
+  G4double CalcEnergy(const G4double T);
+	
+  G4double CalcEntropy(const G4double T, const G4double FreeVol);
+
+private:
+
+  // Copy constructor
+  G4StatMFMacroNucleon(const G4StatMFMacroNucleon & right);
+
+  // operators
+  G4StatMFMacroNucleon & operator=(const G4StatMFMacroNucleon & right);
+  G4bool operator==(const G4StatMFMacroNucleon & right) const;
+  G4bool operator!=(const G4StatMFMacroNucleon & right) const;
+
+  G4double _NeutronMeanMultiplicity;
+  G4double _ProtonMeanMultiplicity;
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMacroTemperature.hh
+++ b/Multifragmentation/include/G4StatMFMacroTemperature.hh
@@ -1,0 +1,116 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroTemperature_h
+#define G4StatMFMacroTemperature_h 1
+
+#include "G4StatMFParameters.hh"
+#include "G4VStatMFMacroCluster.hh"
+#include "G4StatMFMacroChemicalPotential.hh"
+#include "G4Solver.hh"
+
+
+
+class G4StatMFMacroTemperature {
+
+public:
+
+    G4StatMFMacroTemperature(const G4double anA, const G4double aZ, 
+			     const G4double ExEnergy, const G4double FreeE0, 
+			     const G4double kappa, 
+			     std::vector<G4VStatMFMacroCluster*> * ClusterVector);
+	
+    ~G4StatMFMacroTemperature();
+   
+    G4double operator()(const G4double T)
+	{ return (_ExEnergy - this->FragsExcitEnergy(T))/_ExEnergy; }	
+
+private:
+
+    // Default constructor
+    G4StatMFMacroTemperature();
+
+    // copy constructor
+    G4StatMFMacroTemperature(const G4StatMFMacroTemperature &) {};
+
+
+    // operators
+    G4StatMFMacroTemperature & operator=(const G4StatMFMacroTemperature & right);
+    G4bool operator==(const G4StatMFMacroTemperature & right) const;
+    G4bool operator!=(const G4StatMFMacroTemperature & right) const;
+
+public:
+
+    inline G4double GetMeanMultiplicity(void) const {return _MeanMultiplicity;}
+	
+    inline G4double GetChemicalPotentialMu(void) const {return _ChemPotentialMu;}
+
+    inline G4double GetChemicalPotentialNu(void) const {return _ChemPotentialNu;}
+
+    inline G4double GetTemperature(void) const {return _MeanTemperature;}
+
+    inline G4double GetEntropy(void) const {return _MeanEntropy;}
+
+    G4double CalcTemperature(void);
+
+private:
+	
+    G4double FragsExcitEnergy(const G4double T);
+
+    void CalcChemicalPotentialNu(const G4double T);
+
+private:
+
+    G4double theA;
+
+    G4double theZ;
+
+    G4double _ExEnergy;
+	
+    G4double _FreeInternalE0;
+
+    G4double _Kappa;
+
+    G4double _MeanMultiplicity;
+
+    G4double _MeanTemperature;
+	
+    G4double _ChemPotentialMu;
+	
+    G4double _ChemPotentialNu;
+	
+    G4double _MeanEntropy;
+	
+    std::vector<G4VStatMFMacroCluster*> * _theClusters; 
+
+
+};
+#endif

--- a/Multifragmentation/include/G4StatMFMacroTetraNucleon.hh
+++ b/Multifragmentation/include/G4StatMFMacroTetraNucleon.hh
@@ -1,0 +1,67 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroTetraNucleon_h
+#define G4StatMFMacroTetraNucleon_h 1
+
+#include "G4VStatMFMacroCluster.hh"
+#include "G4NucleiProperties.hh"
+
+class G4StatMFMacroTetraNucleon : public G4VStatMFMacroCluster {
+
+public:
+
+  G4StatMFMacroTetraNucleon();
+
+  ~G4StatMFMacroTetraNucleon();
+	
+  G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+				const G4double nu, const G4double T);
+								
+  inline G4double CalcZARatio(const G4double ) {return theZARatio = 0.5;}
+
+  G4double CalcEnergy(const G4double T);
+
+  G4double CalcEntropy(const G4double T, const G4double FreeVol);
+
+private:
+
+  // Copy constructor
+  G4StatMFMacroTetraNucleon(const G4StatMFMacroTetraNucleon & right);
+
+  // operators
+  G4StatMFMacroTetraNucleon & operator=(const G4StatMFMacroTetraNucleon & right);
+  G4bool operator==(const G4StatMFMacroTetraNucleon & right) const;
+  G4bool operator!=(const G4StatMFMacroTetraNucleon & right) const;
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMacroTriNucleon.hh
+++ b/Multifragmentation/include/G4StatMFMacroTriNucleon.hh
@@ -1,0 +1,67 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMacroTriNucleon_h
+#define G4StatMFMacroTriNucleon_h 1
+
+#include "G4VStatMFMacroCluster.hh"
+#include "G4NucleiProperties.hh"
+
+class G4StatMFMacroTriNucleon : public G4VStatMFMacroCluster {
+
+public:
+
+  G4StatMFMacroTriNucleon();
+
+  ~G4StatMFMacroTriNucleon();
+
+  G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+				const G4double nu, const G4double T);
+
+  inline G4double CalcZARatio(const G4double ) {return theZARatio = 0.5;}
+
+  G4double CalcEnergy(const G4double T);
+	
+  G4double CalcEntropy(const G4double T, const G4double FreeVol);
+	
+private:
+
+  // Copy constructor
+  G4StatMFMacroTriNucleon(const G4StatMFMacroTriNucleon & right);
+
+  // operators
+  G4StatMFMacroTriNucleon & operator=(const G4StatMFMacroTriNucleon & right);
+  G4bool operator==(const G4StatMFMacroTriNucleon & right) const;
+  G4bool operator!=(const G4StatMFMacroTriNucleon & right) const;
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMicroCanonical.hh
+++ b/Multifragmentation/include/G4StatMFMicroCanonical.hh
@@ -1,0 +1,132 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMicroCanonical_h
+#define G4StatMFMicroCanonical_h 1
+
+#include <vector>
+
+#include "G4VStatMFEnsemble.hh"
+#include "G4StatMFMicroPartition.hh"
+#include "G4StatMFMicroManager.hh"
+#include "G4StatMFParameters.hh"
+#include "G4StatMFChannel.hh"
+
+#include "G4Fragment.hh"
+#include "Randomize.hh"
+
+
+class G4StatMFMicroCanonical : public G4VStatMFEnsemble {
+
+public:
+
+    // G4StatMFMicroCanonical class must be initialized with a G4Fragment.
+    G4StatMFMicroCanonical(const G4Fragment & theFragment);
+
+    // destructor
+    ~G4StatMFMicroCanonical();
+
+private:
+    // default constructor
+    G4StatMFMicroCanonical() {};
+
+
+    // copy constructor
+    G4StatMFMicroCanonical(const G4StatMFMicroCanonical &right);
+
+
+    // operators
+    G4StatMFMicroCanonical & operator=(const G4StatMFMicroCanonical & right);
+    G4bool operator==(const G4StatMFMicroCanonical & right) const;
+    G4bool operator!=(const G4StatMFMicroCanonical & right) const;
+
+
+public:
+
+    // Choice of fragment atomic numbers and charges.
+    G4StatMFChannel * ChooseAandZ(const G4Fragment & theFragment);
+	
+    enum {MaxAllowedMultiplicity = 4};
+
+private:
+
+    // Initailization method
+    void Initialize(const G4Fragment & theFragment);
+
+    // Calculate Entropy of Compound Nucleus
+    G4double CalcEntropyOfCompoundNucleus(const G4Fragment & theFragment, G4double & TConf);
+
+    G4double CalcFreeInternalEnergy(const G4Fragment & theFragment, G4double T);
+
+    G4double CalcInvLevelDensity(G4int anA);
+	
+	
+// Data members
+private:
+	
+    // This is a vector of partitions managers for partitions of different 
+    // multiplicities:
+    
+    std::vector<G4StatMFMicroManager*> _ThePartitionManagerVector;
+	
+    // Statistical weight of compound nucleus
+    G4double _WCompoundNucleus;
+
+
+  struct DeleteFragment 
+  {
+    template<typename T>
+    void operator()(const T* ptr) const
+    {
+      delete ptr;
+    }
+  };
+
+  class SumProbabilities : public std::binary_function<G4double,G4double,G4double>
+  {
+  public:
+    SumProbabilities() : total(0.0) {}
+    G4double operator() (G4double& /* probSoFar*/, G4StatMFMicroManager*& manager)
+    { 
+      total += manager->GetProbability();
+      return total;
+    }
+    
+    G4double GetTotal() { return total; }
+  public:
+    G4double total;
+    
+  };
+
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFMicroManager.hh
+++ b/Multifragmentation/include/G4StatMFMicroManager.hh
@@ -1,0 +1,135 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#ifndef G4StatMFMicroManager_h
+#define G4StatMFMicroManager_h 1
+
+#include "G4StatMFMicroPartition.hh"
+#include "G4StatMFParameters.hh"
+#include "G4StatMFChannel.hh"
+
+#include "G4Fragment.hh"
+#include "Randomize.hh"
+
+
+class G4StatMFMicroManager {
+
+public:
+
+    // G4StatMFMicroManager class must be initialized with a G4Fragment, multiplicity,
+    // free internal energy and the entropy of the compund nucleus.
+    G4StatMFMicroManager(const G4Fragment & theFragment, G4int multiplicity,
+			 G4double FreeIntE, G4double SCompNuc);
+
+    // destructor
+    ~G4StatMFMicroManager();
+
+private:
+    // default constructor
+    G4StatMFMicroManager() {};
+
+
+    // copy constructor
+    G4StatMFMicroManager(const G4StatMFMicroManager &right);
+
+
+    // operators
+    G4StatMFMicroManager & operator=(const G4StatMFMicroManager & right);
+
+public:
+    G4bool operator==(const G4StatMFMicroManager & right) const;
+    G4bool operator!=(const G4StatMFMicroManager & right) const;
+
+
+public:
+
+    // Choice of fragment atomic numbers and charges.
+    G4StatMFChannel * ChooseChannel(G4int A0, G4int Z0, G4double MeanT);
+	
+    G4double GetProbability(void) const {return _WW;}
+
+    void Normalize(G4double Norm);
+	
+    G4double GetMeanMultiplicity(void) const {return _MeanMultiplicity; }
+
+    G4double GetMeanTemperature(void) const {return _MeanTemperature; }
+
+    G4double GetMeanEntropy(void) const {return _MeanEntropy; }
+
+private:
+
+    // Initailization method
+    void Initialize(const G4Fragment & theFragment, G4int m,
+		    G4double FreeIntE, G4double SCompNuc);
+
+    G4bool MakePartition(G4int k, G4int * ANumbers); 
+								
+
+
+	
+// Data members
+private:
+
+
+    // Partitions vector
+    std::vector<G4StatMFMicroPartition*> _Partition;
+	
+
+    // Statistical weight
+    G4double _WW;
+
+    G4double _Normalization;
+	
+    G4double _MeanMultiplicity;
+
+    G4double _MeanTemperature;
+	
+    G4double _MeanEntropy;
+
+  struct DeleteFragment 
+  {
+    template<typename T>
+    void operator()(const T* ptr) const
+    {
+      delete ptr;
+    }
+  };
+  
+};
+
+#endif
+
+
+
+
+
+

--- a/Multifragmentation/include/G4StatMFMicroPartition.hh
+++ b/Multifragmentation/include/G4StatMFMicroPartition.hh
@@ -1,0 +1,141 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFMicroPartition_h
+#define G4StatMFMicroPartition_h 1
+
+#include  <vector>
+
+#include "globals.hh"
+#include "G4StatMFParameters.hh"
+#include "G4StatMFChannel.hh"
+
+class G4StatMFMicroPartition {
+
+public:
+    // Constructor
+    G4StatMFMicroPartition(G4int A, G4int Z) :
+	theA(A), theZ(Z), _Probability(0.0), _Temperature(0.0), 
+	_Entropy(0.0) {};
+
+
+    // Destructor
+    ~G4StatMFMicroPartition() {};
+
+
+private:
+    // Default constructor
+    G4StatMFMicroPartition() {};
+	
+    // Copy constructor
+    G4StatMFMicroPartition(const G4StatMFMicroPartition & right);
+
+    // operators
+    G4StatMFMicroPartition & operator=(const G4StatMFMicroPartition & right);
+public:
+    G4bool operator==(const G4StatMFMicroPartition & right) const;
+    G4bool operator!=(const G4StatMFMicroPartition & right) const;
+
+public:
+
+    // Gives fragments charges
+    G4StatMFChannel * ChooseZ(G4int A0, G4int Z0, G4double MeanT);	
+
+    G4double GetProbability(void)
+	{ return _Probability; }
+	
+    void SetPartitionFragment(G4int anA)
+	{ 
+	    _thePartition.push_back(anA);
+	    CoulombFreeEnergy(anA);
+	}
+	
+    void Normalize(G4double Normalization)
+	{ _Probability /= Normalization; }
+
+    G4double CalcPartitionProbability(G4double U,
+				      G4double FreeInternalE0,
+				      G4double SCompound);
+								
+    G4double GetTemperature(void)
+	{
+	    return _Temperature;
+	}
+	
+    G4double GetEntropy(void)
+	{
+	    return _Entropy;
+	}
+
+private:
+
+    void CoulombFreeEnergy(G4int anA);
+
+    G4double CalcPartitionTemperature(G4double U, 
+				      G4double FreeInternalE0);
+
+    G4double GetPartitionEnergy(G4double T);
+	
+    G4double GetCoulombEnergy(void);
+
+    G4double GetDegeneracyFactor(G4int A);
+	
+    G4double InvLevelDensity(G4double Af) 
+	{
+	    // Calculate Inverse Density Level
+	    // Epsilon0*(1 + 3 /(Af - 1))
+	    if (Af < 1.5) return 0.0;
+	    else return G4StatMFParameters::GetEpsilon0()*(1.0+3.0/(Af - 1.0));
+	}
+
+private:
+
+    // A and Z of initial nucleus
+    G4int theA;
+    G4int theZ;
+
+    // Partition probability
+    G4double _Probability;
+	
+    // Partition temperature
+    G4double _Temperature;
+	
+    // Partition entropy
+    G4double _Entropy;
+	
+    // The partition itself
+    std::vector<G4int> _thePartition;
+	
+    std::vector<G4double> _theCoulombFreeEnergy;
+
+};
+
+#endif

--- a/Multifragmentation/include/G4StatMFParameters.hh
+++ b/Multifragmentation/include/G4StatMFParameters.hh
@@ -1,0 +1,92 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#ifndef G4StatMFParameters_h
+#define G4StatMFParameters_h 1
+
+#include "globals.hh"
+
+class G4StatMFParameters
+{
+public:
+  
+  G4StatMFParameters();
+
+  ~G4StatMFParameters();
+  
+  static G4double GetKappa();
+  
+  static G4double GetKappaCoulomb(); 
+  
+  static G4double GetEpsilon0();
+  
+  static G4double GetE0();
+  
+  static G4double GetBeta0(); 
+  
+  static G4double GetGamma0();
+  
+  static G4double GetCriticalTemp();
+  
+  static G4double Getr0();
+
+  static G4double GetCoulomb();
+  
+  static G4double Beta(G4double T);
+  
+  static G4double DBetaDT(G4double T);
+  
+  static G4double GetMaxAverageMultiplicity(G4int A);
+
+  // +----------------------+
+  // | Constant Parameters: |
+  // +----------------------+
+  // Kappa is used for calculate volume V_f for translational 
+  // motion of fragments
+  static const G4double fKappa;
+  // KappaCoulomb is used for calculate Coulomb term energy
+  static const G4double fKappaCoulomb;
+  // Inverse level density
+  static const G4double fEpsilon0;
+  // Bethe-Weizsacker coefficients
+  static const G4double fE0;
+  static const G4double fBeta0;
+  static const G4double fGamma0;
+  // Critical temperature (for liquid-gas phase transitions)
+  static const G4double fCriticalTemp;
+  // Nuclear radius
+  static const G4double fr0;
+  // Coulomb 
+  static const G4double fCoulomb;
+
+};
+
+#endif

--- a/Multifragmentation/include/G4VMultiFragmentation.hh
+++ b/Multifragmentation/include/G4VMultiFragmentation.hh
@@ -1,0 +1,58 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara 
+
+#ifndef G4VMultiFragmentation_h
+#define G4VMultiFragmentation_h 1
+
+#include "globals.hh"
+#include "G4Fragment.hh"
+
+class G4VMultiFragmentation 
+{
+public:
+  G4VMultiFragmentation();
+  virtual ~G4VMultiFragmentation();
+  
+private:
+  G4VMultiFragmentation(const G4VMultiFragmentation &right);
+  
+  const G4VMultiFragmentation & operator=(const G4VMultiFragmentation &right);
+  G4bool operator==(const G4VMultiFragmentation &right) const;
+  G4bool operator!=(const G4VMultiFragmentation &right) const;
+  
+public:
+  virtual G4FragmentVector * BreakItUp(const G4Fragment &theNucleus) = 0;
+};
+
+
+#endif
+
+

--- a/Multifragmentation/include/G4VStatMFEnsemble.hh
+++ b/Multifragmentation/include/G4VStatMFEnsemble.hh
@@ -1,0 +1,88 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#ifndef G4VStatMFEnsemble_h
+#define G4VStatMFEnsemble_h 1
+
+#include "G4StatMFParameters.hh"
+#include "G4StatMFChannel.hh"
+
+class G4VStatMFEnsemble {
+
+public:
+    // Default Constructor
+    G4VStatMFEnsemble() :
+	__FreeInternalE0(0.0),
+	__MeanTemperature(0.0),
+	__MeanEntropy(0.0),
+	__MeanMultiplicity(0.0)
+	{};
+
+
+    // Destructor
+    virtual ~G4VStatMFEnsemble() {};
+
+
+private:
+
+    // Copy constructor
+    G4VStatMFEnsemble(const G4VStatMFEnsemble & right);
+
+    // operators
+    G4VStatMFEnsemble & operator=(const G4VStatMFEnsemble & right);
+    G4bool operator==(const G4VStatMFEnsemble & right) const;
+    G4bool operator!=(const G4VStatMFEnsemble & right) const;
+	
+public:
+
+    virtual G4StatMFChannel * ChooseAandZ(const G4Fragment & aFragment) = 0;
+		
+    G4double GetMeanMultiplicity(void) const {return __MeanMultiplicity;}
+	
+    G4double GetMeanTemperature(void) const {return __MeanTemperature;}
+
+protected:
+
+    // Free internal energy at temperature T = 0
+    G4double __FreeInternalE0;
+	
+    // Mean temperature 
+    G4double __MeanTemperature;
+	
+    // Mean Entropy 
+    G4double __MeanEntropy;
+	
+    // Mean Multiplicity
+    G4double __MeanMultiplicity;
+};
+
+#endif

--- a/Multifragmentation/include/G4VStatMFMacroCluster.hh
+++ b/Multifragmentation/include/G4VStatMFMacroCluster.hh
@@ -1,0 +1,140 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#ifndef G4VStatMFMacroCluster_h
+#define G4VStatMFMacroCluster_h 1
+
+#include "G4StatMFParameters.hh"
+#include "G4HadronicException.hh"
+
+class G4VStatMFMacroCluster {
+
+public:
+    // Constructor
+    G4VStatMFMacroCluster(const G4int Size) : 
+	theA(Size),
+	_InvLevelDensity(0.0),
+	_Entropy(0.0),
+	theZARatio(0.0),
+	_MeanMultiplicity(0.0),
+	_Energy(0.0)
+	{
+	    if (theA <= 0) throw G4HadronicException(__FILE__, __LINE__, 
+		"G4VStatMFMacroCluster::Constructor: Cluster's size must be >= 1");
+	    _InvLevelDensity = CalcInvLevelDensity();
+	}
+
+
+    // Destructor
+    virtual ~G4VStatMFMacroCluster() {};
+
+
+private:
+
+    // Default constructor
+    G4VStatMFMacroCluster() {};
+
+    // Copy constructor
+    G4VStatMFMacroCluster(const G4VStatMFMacroCluster & right);
+
+    // operators
+    G4VStatMFMacroCluster & operator=(const G4VStatMFMacroCluster & right);
+
+public:
+    G4bool operator==(const G4VStatMFMacroCluster & right) const;
+    G4bool operator!=(const G4VStatMFMacroCluster & right) const;
+
+private:
+    G4double CalcInvLevelDensity(void);
+	
+public:
+
+    virtual G4double CalcMeanMultiplicity(const G4double FreeVol, const G4double mu, 
+					  const G4double nu, const G4double T) = 0;
+						
+    virtual G4double CalcZARatio(const G4double nu) = 0;
+	
+    G4double GetMeanMultiplicity(void) const { return _MeanMultiplicity; }
+
+    virtual G4double CalcEnergy(const G4double T) = 0;
+
+    virtual G4double CalcEntropy(const G4double T, const G4double FreeVol) = 0;
+
+protected:
+    // Number of nucleons in the cluster
+    G4int theA;
+	
+    // Inverse level density
+    G4double _InvLevelDensity;
+	
+    // Entropy
+    G4double _Entropy;
+	
+    // Z/A ratio
+    G4double theZARatio;
+	
+    // Mean Multiplicity
+    G4double _MeanMultiplicity;
+	
+    // Energy
+    G4double _Energy;
+
+// *************************************************************************
+public:
+	
+    G4double GetInvLevelDensity(void) const
+	{ return _InvLevelDensity; }
+	 
+    void SetZARatio(const G4double value)
+	{ theZARatio = value; }
+	
+    G4double GetZARatio(void) const
+	{ return theZARatio; }
+	
+	
+    void SetSize(const G4double value)
+	{ 
+	    if (value <= 0.0) throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFMacroCluster::SetSize: Cluster's size must be >= 1");
+	    theA = G4int(value); 
+	    _InvLevelDensity = CalcInvLevelDensity();
+	}
+	
+    G4double GetSize(void) const
+	{ return theA; }
+
+
+
+
+
+};
+
+#endif

--- a/Multifragmentation/src/G4Solver.cc
+++ b/Multifragmentation/src/G4Solver.cc
@@ -1,0 +1,72 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#include "G4Solver.hh"
+
+template <class Function> 
+G4Solver<Function>::G4Solver(const G4Solver & right)
+{
+    MaxIter = right.MaxIter;
+    tolerance = right.tolerance;
+    a = right.a;
+    b = right.b;
+    root = right.root;
+}
+
+// operators
+template <class Function> 
+G4Solver<Function> & G4Solver<Function>::operator=(const G4Solver & right)
+{
+    MaxIter = right.MaxIter;
+    tolerance = right.tolerance;
+    a = right.a;
+    b = right.b;
+    root = right.root;	
+    return *this;
+}
+
+template <class Function> 
+G4bool G4Solver<Function>::operator==(const G4Solver & right) const
+{
+    if (this == &right) return true;
+    else return false;
+}
+
+template <class Function> 
+G4bool G4Solver<Function>::operator!=(const G4Solver & right) const
+{
+    return !operator==(right);
+}
+	
+
+
+

--- a/Multifragmentation/src/G4StatMF.cc
+++ b/Multifragmentation/src/G4StatMF.cc
@@ -1,0 +1,283 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMF.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Pow.hh"
+
+// Default constructor
+G4StatMF::G4StatMF() : _theEnsemble(0) {}
+
+
+// Destructor
+G4StatMF::~G4StatMF() {} //{if (_theEnsemble != 0) delete _theEnsemble;}
+
+
+G4FragmentVector * G4StatMF::BreakItUp(const G4Fragment &theFragment)
+{
+  // 	G4FragmentVector * theResult = new G4FragmentVector;
+
+  if (theFragment.GetExcitationEnergy() <= 0.0) {
+    //G4FragmentVector * theResult = new G4FragmentVector;
+    //theResult->push_back(new G4Fragment(theFragment));
+    return 0;
+  }
+
+
+  // Maximun average multiplicity: M_0 = 2.6 for A ~ 200 
+  // and M_0 = 3.3 for A <= 110
+  G4double MaxAverageMultiplicity = 
+    G4StatMFParameters::GetMaxAverageMultiplicity(theFragment.GetA_asInt());
+
+	
+    // We'll use two kinds of ensembles
+  G4StatMFMicroCanonical * theMicrocanonicalEnsemble = 0;
+  G4StatMFMacroCanonical * theMacrocanonicalEnsemble = 0;
+	
+  //-------------------------------------------------------
+  // Direct simulation part (Microcanonical ensemble)
+  //-------------------------------------------------------
+  
+  // Microcanonical ensemble initialization 
+  theMicrocanonicalEnsemble = new G4StatMFMicroCanonical(theFragment);
+
+  G4int Iterations = 0;
+  G4int IterationsLimit = 100000;
+  G4double Temperature = 0.0;
+  
+  G4bool FirstTime = true;
+  G4StatMFChannel * theChannel = 0;
+ 
+  G4bool ChannelOk;
+  do {  // Try to de-excite as much as IterationLimit permits
+    do {
+      
+      G4double theMeanMult = theMicrocanonicalEnsemble->GetMeanMultiplicity();
+      if (theMeanMult <= MaxAverageMultiplicity) {
+	// G4cout << "MICROCANONICAL" << G4endl;
+	// Choose fragments atomic numbers and charges from direct simulation
+	theChannel = theMicrocanonicalEnsemble->ChooseAandZ(theFragment);
+	_theEnsemble = theMicrocanonicalEnsemble;
+      } else {
+	//-----------------------------------------------------
+	// Non direct simulation part (Macrocanonical Ensemble)
+	//-----------------------------------------------------
+	if (FirstTime) {
+	  // Macrocanonical ensemble initialization 
+	  theMacrocanonicalEnsemble = new G4StatMFMacroCanonical(theFragment);
+	  _theEnsemble = theMacrocanonicalEnsemble;
+	  FirstTime = false;
+	}
+	// G4cout << "MACROCANONICAL" << G4endl;
+	// Select calculated fragment total multiplicity, 
+	// fragment atomic numbers and fragment charges.
+	theChannel = theMacrocanonicalEnsemble->ChooseAandZ(theFragment);
+      }
+      
+      ChannelOk = theChannel->CheckFragments();
+      if (!ChannelOk) delete theChannel; 
+      
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+    } while (!ChannelOk);
+    
+    
+    if (theChannel->GetMultiplicity() <= 1) {
+      G4FragmentVector * theResult = new G4FragmentVector;
+      theResult->push_back(new G4Fragment(theFragment));
+      delete theMicrocanonicalEnsemble;
+      if (theMacrocanonicalEnsemble != 0) delete theMacrocanonicalEnsemble;
+      delete theChannel;
+      return theResult;
+    }
+    
+    //--------------------------------------
+    // Second part of simulation procedure.
+    //--------------------------------------
+    
+    // Find temperature of breaking channel.
+    Temperature = _theEnsemble->GetMeanTemperature(); // Initial guess for Temperature 
+ 
+    if (FindTemperatureOfBreakingChannel(theFragment,theChannel,Temperature)) break;
+ 
+    // Do not forget to delete this unusable channel, for which we failed to find the temperature,
+    // otherwise for very proton-reach nuclei it would lead to memory leak due to large 
+    // number of iterations. N.B. "theChannel" is created in G4StatMFMacroCanonical::ChooseZ()
+
+    // G4cout << " Iteration # " << Iterations << " Mean Temperature = " << Temperature << G4endl;    
+
+    delete theChannel;    
+
+    // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  } while (Iterations++ < IterationsLimit );
+  
+ 
+
+  // If Iterations >= IterationsLimit means that we couldn't solve for temperature
+  if (Iterations >= IterationsLimit) 
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMF::BreakItUp: Was not possible to solve for temperature of breaking channel");
+  
+  
+  G4FragmentVector * theResult = theChannel->
+    GetFragments(theFragment.GetA_asInt(),theFragment.GetZ_asInt(),Temperature);
+  
+  
+	
+  // ~~~~~~ Energy conservation Patch !!!!!!!!!!!!!!!!!!!!!!
+  // Original nucleus 4-momentum in CM system
+  G4LorentzVector InitialMomentum(theFragment.GetMomentum());
+  InitialMomentum.boost(-InitialMomentum.boostVector());
+  G4double ScaleFactor = 0.0;
+  G4double SavedScaleFactor = 0.0;
+  do {
+    G4double FragmentsEnergy = 0.0;
+    G4FragmentVector::iterator j;
+    for (j = theResult->begin(); j != theResult->end(); j++) 
+      FragmentsEnergy += (*j)->GetMomentum().e();
+    SavedScaleFactor = ScaleFactor;
+    ScaleFactor = InitialMomentum.e()/FragmentsEnergy;
+    G4ThreeVector ScaledMomentum(0.0,0.0,0.0);
+    for (j = theResult->begin(); j != theResult->end(); j++) {
+      ScaledMomentum = ScaleFactor * (*j)->GetMomentum().vect();
+      G4double Mass = (*j)->GetMomentum().m();
+      G4LorentzVector NewMomentum;
+      NewMomentum.setVect(ScaledMomentum);
+      NewMomentum.setE(std::sqrt(ScaledMomentum.mag2()+Mass*Mass));
+      (*j)->SetMomentum(NewMomentum);		
+    }
+    // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  } while (ScaleFactor > 1.0+1.e-5 && std::abs(ScaleFactor-SavedScaleFactor)/ScaleFactor > 1.e-10);
+  // ~~~~~~ End of patch !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  
+  // Perform Lorentz boost
+  G4FragmentVector::iterator i;
+  for (i = theResult->begin(); i != theResult->end(); i++) {
+    G4LorentzVector FourMom = (*i)->GetMomentum();
+    FourMom.boost(theFragment.GetMomentum().boostVector());
+    (*i)->SetMomentum(FourMom);
+  }
+  
+  // garbage collection
+  delete theMicrocanonicalEnsemble;
+  if (theMacrocanonicalEnsemble != 0) delete theMacrocanonicalEnsemble;
+  delete theChannel;
+  
+  return theResult;
+}
+
+
+G4bool G4StatMF::FindTemperatureOfBreakingChannel(const G4Fragment & theFragment,
+						  const G4StatMFChannel * aChannel,
+						  G4double & Temperature)
+  // This finds temperature of breaking channel.
+{
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  G4double U = theFragment.GetExcitationEnergy();
+  
+  G4double T = std::max(Temperature,0.0012*MeV);  
+  G4double Ta = T;
+  G4double TotalEnergy = CalcEnergy(A,Z,aChannel,T);
+  
+  G4double Da = (U - TotalEnergy)/U;
+  G4double Db = 0.0;
+  
+  // bracketing the solution
+  if (Da == 0.0) {
+    Temperature = T;
+    return true;
+  } else if (Da < 0.0) {
+    do {
+      T *= 0.5;
+      if (T < 0.001*MeV) return false;
+      
+      TotalEnergy = CalcEnergy(A,Z,aChannel,T);
+      
+      Db = (U - TotalEnergy)/U;
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+    } while (Db < 0.0);
+    
+  } else {
+    do {
+      T *= 1.5;
+      
+      TotalEnergy = CalcEnergy(A,Z,aChannel,T);
+      
+      Db = (U - TotalEnergy)/U;
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+    } while (Db > 0.0); 
+  }
+  
+  G4double eps = 1.0e-14 * std::abs(T-Ta);
+  //G4double eps = 1.0e-3 ;
+  
+  // Start the bisection method
+  for (G4int j = 0; j < 1000; j++) {
+    G4double Tc =  (Ta+T)*0.5;
+    if (std::abs(Ta-Tc) <= eps) {
+      Temperature = Tc;
+      return true;
+    }
+    
+    T = Tc;
+    
+    TotalEnergy = CalcEnergy(A,Z,aChannel,T);
+    
+    G4double Dc = (U - TotalEnergy)/U; 
+    
+    if (Dc == 0.0) {
+      Temperature  = Tc;
+      return true;
+    }
+    
+    if (Da*Dc < 0.0) {
+      T  = Tc;
+      Db = Dc;
+    } else {
+      Ta = Tc;
+      Da = Dc;
+    }
+  }
+  
+  Temperature  = (Ta+T)*0.5;
+  return false;
+}
+
+G4double G4StatMF::CalcEnergy(G4int A, G4int Z, const G4StatMFChannel * aChannel,
+			      G4double T)
+{
+  G4double MassExcess0 = G4NucleiProperties::GetMassExcess(A,Z);
+  G4double ChannelEnergy = aChannel->GetFragmentsEnergy(T);
+  return -MassExcess0 + G4StatMFParameters::GetCoulomb() + ChannelEnergy;
+}
+
+
+

--- a/Multifragmentation/src/G4StatMFChannel.cc
+++ b/Multifragmentation/src/G4StatMFChannel.cc
@@ -1,0 +1,462 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+//
+// Modified:
+// 25.07.08 I.Pshenichnov (in collaboration with Alexander Botvina and Igor 
+//          Mishustin (FIAS, Frankfurt, INR, Moscow and Kurchatov Institute, 
+//          Moscow, pshenich@fias.uni-frankfurt.de) fixed semi-infinite loop 
+// _NumOfChargedFragments > 1 FIX 19.11.2021
+//  file from geant4.10.04.p03
+
+#include <numeric>
+
+#include "G4StatMFChannel.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4HadronicException.hh"
+#include "Randomize.hh"
+#include "G4Pow.hh"
+#include "G4Exp.hh"
+#include "G4RandomDirection.hh"
+
+class SumCoulombEnergy : public std::binary_function<G4double,G4double,G4double>
+{
+public:
+  SumCoulombEnergy() : total(0.0) {}
+  G4double operator() (G4double& , G4StatMFFragment*& frag)
+  { 
+      total += frag->GetCoulombEnergy();
+      return total;
+  }
+    
+  G4double GetTotal() { return total; }
+public:
+  G4double total;  
+};
+
+G4StatMFChannel::G4StatMFChannel() : 
+  _NumOfNeutralFragments(0), 
+  _NumOfChargedFragments(0)
+{}
+
+G4StatMFChannel::~G4StatMFChannel() 
+{ 
+  if (!_theFragments.empty()) {
+    std::for_each(_theFragments.begin(),_theFragments.end(),
+		  DeleteFragment());
+  }
+}
+
+G4bool G4StatMFChannel::CheckFragments(void)
+{
+  std::deque<G4StatMFFragment*>::iterator i;
+  for (i = _theFragments.begin(); 
+       i != _theFragments.end(); ++i) 
+    {
+      G4int A = (*i)->GetA();
+      G4int Z = (*i)->GetZ();
+      if ( (A > 1 && (Z > A || Z <= 0)) || (A==1 && Z > A) || A <= 0 ) return false;
+    }
+    return true;
+}
+
+void G4StatMFChannel::CreateFragment(G4int A, G4int Z)
+// Create a new fragment.
+// Fragments are automatically sorted: first charged fragments, 
+// then neutral ones.
+{
+  if (Z <= 0.5) {
+    _theFragments.push_back(new G4StatMFFragment(A,Z));
+    _NumOfNeutralFragments++;
+  } else {
+    _theFragments.push_front(new G4StatMFFragment(A,Z));
+    _NumOfChargedFragments++;
+  }
+	
+  return;
+}
+
+G4double G4StatMFChannel::GetFragmentsCoulombEnergy(void)
+{
+  G4double Coulomb = std::accumulate(_theFragments.begin(),_theFragments.end(),
+				     0.0,SumCoulombEnergy());
+  //      G4double Coulomb = 0.0;
+  //      for (unsigned int i = 0;i < _theFragments.size(); i++)
+  //  	Coulomb += _theFragments[i]->GetCoulombEnergy();
+  return Coulomb;
+}
+
+G4double G4StatMFChannel::GetFragmentsEnergy(G4double T) const
+{
+  G4double Energy = 0.0;
+	
+  G4double TranslationalEnergy = 1.5*T*_theFragments.size();
+
+  std::deque<G4StatMFFragment*>::const_iterator i;
+  for (i = _theFragments.begin(); i != _theFragments.end(); ++i)
+    {
+      Energy += (*i)->GetEnergy(T);
+    }
+  return Energy + TranslationalEnergy;	
+}
+
+G4FragmentVector * G4StatMFChannel::GetFragments(G4int anA, 
+						 G4int anZ,
+						 G4double T)
+{
+  // calculate momenta of charged fragments  
+  CoulombImpulse(anA,anZ,T);
+	
+  // calculate momenta of neutral fragments
+  FragmentsMomenta(_NumOfNeutralFragments, _NumOfChargedFragments, T);
+
+  G4FragmentVector * theResult = new G4FragmentVector;
+  std::deque<G4StatMFFragment*>::iterator i;
+  for (i = _theFragments.begin(); i != _theFragments.end(); ++i)
+    theResult->push_back((*i)->GetFragment(T));
+
+  return theResult;
+}
+
+void G4StatMFChannel::CoulombImpulse(G4int anA, G4int anZ, G4double T)
+// Aafter breakup, fragments fly away under Coulomb field.
+// This method calculates asymptotic fragments momenta.
+{
+  // First, we have to place the fragments inside of the original nucleus volume
+  PlaceFragments(anA);
+	
+  // Second, we sample initial charged fragments momenta. There are
+  // _NumOfChargedFragments charged fragments and they start at the begining
+  // of the vector _theFragments (i.e. 0)
+  FragmentsMomenta(_NumOfChargedFragments, 0, T);
+
+  // Third, we have to figure out the asymptotic momenta of charged fragments 
+  // For taht we have to solve equations of motion for fragments
+  if(_NumOfChargedFragments > 1){
+    SolveEqOfMotion(anA,anZ,T);
+  }
+
+  return;
+}
+
+void G4StatMFChannel::PlaceFragments(G4int anA)
+// This gives the position of fragments at the breakup instant. 
+// Fragments positions are sampled inside prolongated ellipsoid.
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  const G4double R0 = G4StatMFParameters::Getr0();
+  G4double Rsys = 2.0*R0*g4calc->Z13(anA);
+
+  G4bool TooMuchIterations;
+  do 
+    {
+      TooMuchIterations = false;
+	
+      // Sample the position of the first fragment
+      G4double R = (Rsys - R0*g4calc->Z13(_theFragments[0]->GetA()))*
+	g4calc->A13(G4UniformRand());
+      _theFragments[0]->SetPosition(R*G4RandomDirection());
+	
+	
+      // Sample the position of the remaining fragments
+      G4bool ThereAreOverlaps = false;
+      std::deque<G4StatMFFragment*>::iterator i;
+      for (i = _theFragments.begin()+1; i != _theFragments.end(); ++i) 
+	{
+	  G4int counter = 0;
+	  do 
+	    {
+	      R = (Rsys - R0*g4calc->Z13((*i)->GetA()))*g4calc->A13(G4UniformRand());
+	      (*i)->SetPosition(R*G4RandomDirection());
+		
+	      // Check that there are not overlapping fragments
+	      std::deque<G4StatMFFragment*>::iterator j;
+	      for (j = _theFragments.begin(); j != i; ++j) 
+		{
+		  G4ThreeVector FragToFragVector = 
+		    (*i)->GetPosition() - (*j)->GetPosition();
+		  G4double Rmin = R0*(g4calc->Z13((*i)->GetA()) +
+				      g4calc->Z13((*j)->GetA()));
+		  if ( (ThereAreOverlaps = (FragToFragVector.mag2() < Rmin*Rmin))) 
+		    { break; }
+		}
+	      counter++;
+	      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+	    } while (ThereAreOverlaps && counter < 1000);
+	    
+	  if (counter >= 1000) 
+	    {
+	      TooMuchIterations = true;
+	      break;
+	    } 
+	}
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+    } while (TooMuchIterations);
+    return;
+}
+
+void G4StatMFChannel::FragmentsMomenta(G4int NF, G4int idx,
+				       G4double T)
+// Calculate fragments momenta at the breakup instant
+// Fragment kinetic energies are calculated according to the 
+// Boltzmann distribution at given temperature.
+// NF is number of fragments
+// idx is index of first fragment
+{
+  G4double KinE = 1.5*T*NF;	
+  G4ThreeVector p(0.,0.,0.);
+	
+  if (NF <= 0) return;
+  else if (NF == 1) 
+    {
+      // We have only one fragment to deal with
+      p = std::sqrt(2.0*_theFragments[idx]->GetNuclearMass()*KinE)
+	*G4RandomDirection();
+      _theFragments[idx]->SetMomentum(p);
+    } 
+  else if (NF == 2) 
+    {
+      // We have only two fragment to deal with
+      G4double M1 = _theFragments[idx]->GetNuclearMass();
+      G4double M2 = _theFragments[idx+1]->GetNuclearMass();
+      p = std::sqrt(2.0*KinE*(M1*M2)/(M1+M2))*G4RandomDirection();		
+      _theFragments[idx]->SetMomentum(p);
+      _theFragments[idx+1]->SetMomentum(-p);
+    } 
+  else 
+    {
+      // We have more than two fragments
+      G4double AvailableE;
+      G4int i1,i2;
+      G4double SummedE;
+      G4ThreeVector SummedP(0.,0.,0.);
+      do 
+	{
+	  // Fisrt sample momenta of NF-2 fragments 
+	  // according to Boltzmann distribution
+	  AvailableE = 0.0;
+	  SummedE = 0.0;
+	  SummedP.setX(0.0);SummedP.setY(0.0);SummedP.setZ(0.0);
+	  for (G4int i = idx; i < idx+NF-2; ++i) 
+	    {
+	      G4double E;
+	      G4double RandE;
+	      do 
+		{
+		  E = 9.0*G4UniformRand();
+		  RandE = std::sqrt(0.5/E)*G4Exp(E-0.5)*G4UniformRand();
+		} 
+	      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+	      while (RandE > 1.0);
+	      E *= T;
+	      p = std::sqrt(2.0*E*_theFragments[i]->GetNuclearMass())
+		*G4RandomDirection();
+	      _theFragments[i]->SetMomentum(p);
+	      SummedE += E;
+	      SummedP += p;
+	    }	
+	  // Calculate momenta of last two fragments in such a way
+	  // that constraints are satisfied
+	  i1 = idx+NF-2;  // before last fragment index
+	  i2 = idx+NF-1;  // last fragment index
+	  p = -SummedP;
+	  AvailableE = KinE - SummedE;
+	  // Available Kinetic Energy should be shared between two last fragments
+	} 
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+      while (AvailableE <= p.mag2()/(2.0*(_theFragments[i1]->GetNuclearMass()+
+					  _theFragments[i2]->GetNuclearMass())));
+      G4double H = 1.0 + _theFragments[i2]->GetNuclearMass()
+	/_theFragments[i1]->GetNuclearMass();
+      G4double CTM12 = H*(1.0 - 2.0*_theFragments[i2]->GetNuclearMass()
+			  *AvailableE/p.mag2());
+      G4double CosTheta1;
+      G4double Sign;
+
+      if (CTM12 > 1.) {CosTheta1 = 1.;} 
+      else {
+	do 
+	  {
+	    do 
+	      {
+		CosTheta1 = 1.0 - 2.0*G4UniformRand();
+	      } 
+	    // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+	    while (CosTheta1*CosTheta1 < CTM12);
+	  }
+	// Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+	while (CTM12 >= 0.0 && CosTheta1 < 0.0);
+      }
+
+      if (CTM12 < 0.0) Sign = 1.0;
+      else if (G4UniformRand() <= 0.5) Sign = -1.0;
+      else Sign = 1.0;		
+		
+      G4double P1 = (p.mag()*CosTheta1+Sign*std::sqrt(p.mag2()
+						      *(CosTheta1*CosTheta1-CTM12)))/H;
+      G4double P2 = std::sqrt(P1*P1+p.mag2() - 2.0*P1*p.mag()*CosTheta1);
+      G4double Phi = twopi*G4UniformRand();
+      G4double SinTheta1 = std::sqrt(1.0 - CosTheta1*CosTheta1);
+      G4double CosPhi1 = std::cos(Phi);
+      G4double SinPhi1 = std::sin(Phi);
+      G4double CosPhi2 = -CosPhi1;
+      G4double SinPhi2 = -SinPhi1;
+      G4double CosTheta2 = (p.mag2() + P2*P2 - P1*P1)/(2.0*p.mag()*P2);
+      G4double SinTheta2 = 0.0;
+      if (CosTheta2 > -1.0 && CosTheta2 < 1.0) {
+	SinTheta2 = std::sqrt(1.0 - CosTheta2*CosTheta2);
+      }
+      G4ThreeVector p1(P1*SinTheta1*CosPhi1,P1*SinTheta1*SinPhi1,P1*CosTheta1);
+      G4ThreeVector p2(P2*SinTheta2*CosPhi2,P2*SinTheta2*SinPhi2,P2*CosTheta2);
+      G4ThreeVector b(1.0,0.0,0.0);
+	
+      p1 = RotateMomentum(p,b,p1);
+      p2 = RotateMomentum(p,b,p2);
+	
+      SummedP += p1 + p2;
+      SummedE += p1.mag2()/(2.0*_theFragments[i1]->GetNuclearMass()) + 
+	p2.mag2()/(2.0*_theFragments[i2]->GetNuclearMass());		
+		
+      _theFragments[i1]->SetMomentum(p1);
+      _theFragments[i2]->SetMomentum(p2);
+		
+    }
+  return;
+}
+
+void G4StatMFChannel::SolveEqOfMotion(G4int anA, G4int anZ, G4double T)
+// This method will find a solution of Newton's equation of motion
+// for fragments in the self-consistent time-dependent Coulomb field
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double CoulombEnergy = 0.6*elm_coupling*anZ*anZ*
+    g4calc->A13(1.0+G4StatMFParameters::GetKappaCoulomb())/
+    (G4StatMFParameters::Getr0()*g4calc->Z13(anA)) - GetFragmentsCoulombEnergy();
+  if (CoulombEnergy <= 0.0) return;
+  
+  G4int Iterations = 0;
+  G4double TimeN = 0.0;
+  G4double TimeS = 0.0;
+  G4double DeltaTime = 10.0;
+  
+  G4ThreeVector * Pos = new G4ThreeVector[_NumOfChargedFragments];
+  G4ThreeVector * Vel = new G4ThreeVector[_NumOfChargedFragments];
+  G4ThreeVector * Accel = new G4ThreeVector[_NumOfChargedFragments];
+  
+  G4int i;
+  for (i = 0; i < _NumOfChargedFragments; i++) 
+    {
+      Vel[i] = (1.0/(_theFragments[i]->GetNuclearMass()))*
+	_theFragments[i]->GetMomentum();
+      Pos[i] = _theFragments[i]->GetPosition();
+    }
+
+  G4ThreeVector distance(0.,0.,0.);
+  G4ThreeVector force(0.,0.,0.);
+  G4ThreeVector SavedVel(0.,0.,0.);
+  do {
+    for (i = 0; i < _NumOfChargedFragments; i++) 
+      {
+	force.set(0.,0.,0.); 
+	for (G4int j = 0; j < _NumOfChargedFragments; j++) 
+	  {
+	    if (i != j) 
+	      {
+		distance = Pos[i] - Pos[j];
+		force += (elm_coupling*_theFragments[i]->GetZ()
+			  *_theFragments[j]->GetZ()/
+			  (distance.mag2()*distance.mag()))*distance;
+	      }
+	  }
+	Accel[i] = (1./(_theFragments[i]->GetNuclearMass()))*force;
+      }
+
+    TimeN = TimeS + DeltaTime;
+	
+    for ( i = 0; i < _NumOfChargedFragments; i++) 
+      {
+	SavedVel = Vel[i];
+	Vel[i] += Accel[i]*(TimeN-TimeS);
+	Pos[i] += (SavedVel+Vel[i])*(TimeN-TimeS)*0.5;
+      }
+    TimeS = TimeN;
+    
+    // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  } while (Iterations++ < 100);
+	
+  // Summed fragment kinetic energy
+  G4double TotalKineticEnergy = 0.0;
+  for (i = 0; i < _NumOfChargedFragments; i++) 
+    {
+      TotalKineticEnergy += _theFragments[i]->GetNuclearMass()*
+	0.5*Vel[i].mag2();
+    }
+  // Scaling of fragment velocities
+  G4double KineticEnergy = 1.5*_theFragments.size()*T;
+  G4double Eta = ( CoulombEnergy + KineticEnergy ) / TotalKineticEnergy;
+  for (i = 0; i < _NumOfChargedFragments; i++) 
+    {
+      Vel[i] *= Eta;
+    }
+  
+  // Finally calculate fragments momenta
+  for (i = 0; i < _NumOfChargedFragments; i++) 
+    {
+      _theFragments[i]->SetMomentum(_theFragments[i]->GetNuclearMass()*Vel[i]);
+    }
+  
+  // garbage collection
+  delete [] Pos;
+  delete [] Vel;
+  delete [] Accel;
+  
+  return;
+}
+
+G4ThreeVector G4StatMFChannel::RotateMomentum(G4ThreeVector Pa,
+					      G4ThreeVector V, G4ThreeVector P)
+    // Rotates a 3-vector P to close momentum triangle Pa + V + P = 0
+{
+  G4ThreeVector U = Pa.unit();
+  
+  G4double Alpha1 = U * V;
+  
+  G4double Alpha2 = std::sqrt(V.mag2() - Alpha1*Alpha1);
+
+  G4ThreeVector N = (1./Alpha2)*U.cross(V);
+  
+  G4ThreeVector RotatedMomentum(
+				( (V.x() - Alpha1*U.x())/Alpha2 ) * P.x() + N.x() * P.y() + U.x() * P.z(),
+				( (V.y() - Alpha1*U.y())/Alpha2 ) * P.x() + N.y() * P.y() + U.y() * P.z(),
+				( (V.z() - Alpha1*U.z())/Alpha2 ) * P.x() + N.z() * P.y() + U.z() * P.z()
+				);
+  return RotatedMomentum;
+}
+

--- a/Multifragmentation/src/G4StatMFFragment.cc
+++ b/Multifragmentation/src/G4StatMFFragment.cc
@@ -1,0 +1,132 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFFragment.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4HadronicException.hh"
+#include "G4Pow.hh"
+
+// Copy constructor
+G4StatMFFragment::G4StatMFFragment(const G4StatMFFragment & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFFragment::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4StatMFFragment & G4StatMFFragment::
+operator=(const G4StatMFFragment & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFFragment::operator= meant to not be accessable");
+    return *this;
+}
+
+G4bool G4StatMFFragment::operator==(const G4StatMFFragment & ) const
+{
+//	throw G4HadronicException(__FILE__, __LINE__, "G4StatMFFragment::operator== meant to not be accessable");
+    return false;
+}
+ 
+G4bool G4StatMFFragment::operator!=(const G4StatMFFragment & ) const
+{
+//	throw G4HadronicException(__FILE__, __LINE__, "G4StatMFFragment::operator!= meant to not be accessable");
+    return true;
+}
+
+G4double G4StatMFFragment::GetCoulombEnergy(void) const
+{
+  G4double res = 0.0;
+  if (theZ >= 1) {
+    res = G4StatMFParameters::GetCoulomb();
+  }
+  return res;
+}
+
+G4double G4StatMFFragment::GetEnergy(const G4double T) const
+{
+  if (theA < 1 || theZ < 0 || theZ > theA) {
+    G4cout << "G4StatMFFragment::GetEnergy: A = " << theA 
+	   << ", Z = " << theZ << G4endl;
+    throw G4HadronicException(__FILE__, __LINE__, 
+			      "G4StatMFFragment::GetEnergy: Wrong values for A and Z!");
+  }
+  G4double BulkEnergy = G4NucleiProperties::GetMassExcess(theA,theZ);
+	
+  if (theA < 4) return BulkEnergy - GetCoulombEnergy();
+	
+  G4double SurfaceEnergy;
+  if (G4StatMFParameters::DBetaDT(T) == 0.0) SurfaceEnergy = 0.0;
+  else SurfaceEnergy = 2.5*G4Pow::GetInstance()->Z23(theA)*T*T*
+	 G4StatMFParameters::GetBeta0()/
+	 (G4StatMFParameters::GetCriticalTemp()*
+	  G4StatMFParameters::GetCriticalTemp());
+					 				 
+  G4double ExchangeEnergy = theA*T*T/GetInvLevelDensity();
+  if (theA != 4) ExchangeEnergy += SurfaceEnergy;		  
+  return BulkEnergy + ExchangeEnergy - GetCoulombEnergy();
+}
+
+G4double G4StatMFFragment::GetInvLevelDensity(void) const
+{
+  G4double res = 0.0;
+  if (theA > 1) {
+    res =  G4StatMFParameters::GetEpsilon0()*(1.0+3.0/(theA - 1.0));
+  }
+  return res;
+}
+
+G4Fragment * G4StatMFFragment::GetFragment(const G4double T)
+{
+  G4double U = CalcExcitationEnergy(T);
+  G4double M = GetNuclearMass();
+  G4LorentzVector FourMomentum(_momentum,std::sqrt(_momentum.mag2()+(M+U)*(M+U)));
+  G4Fragment * theFragment = new G4Fragment(theA, theZ, FourMomentum);
+  return theFragment;
+}
+
+G4double G4StatMFFragment::CalcExcitationEnergy(const G4double T)
+{
+  if (theA <= 3) return 0.0;
+	
+  G4double BulkEnergy = theA*T*T/GetInvLevelDensity();
+	
+  // if it is an alpha particle: done
+  if (theA == 4) return BulkEnergy;
+    
+  // Term connected with surface energy
+  G4double SurfaceEnergy = 0.0;
+  G4double q = G4StatMFParameters::DBetaDT(T);
+  if (std::abs(q) > 1.0e-20) { 
+    SurfaceEnergy = 2.5*G4Pow::GetInstance()->Z23(theA)
+      *(G4StatMFParameters::Beta(T) - T*q - G4StatMFParameters::GetBeta0());
+  }
+  return BulkEnergy + SurfaceEnergy;
+}

--- a/Multifragmentation/src/G4StatMFMacroBiNucleon.cc
+++ b/Multifragmentation/src/G4StatMFMacroBiNucleon.cc
@@ -1,0 +1,108 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMacroBiNucleon.hh"
+#include "G4StatMFParameters.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+#include "G4Pow.hh"
+
+// Operators
+
+static const G4double degeneracy = 3.0;
+
+G4StatMFMacroBiNucleon & G4StatMFMacroBiNucleon::
+operator=(const G4StatMFMacroBiNucleon & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroBiNucleon::operator= meant to not be accessable");
+    return *this;
+}
+
+G4bool G4StatMFMacroBiNucleon::operator==(const G4StatMFMacroBiNucleon & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroBiNucleon::operator== meant to not be accessable");
+    return false;
+}
+ 
+
+G4bool G4StatMFMacroBiNucleon::operator!=(const G4StatMFMacroBiNucleon & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroBiNucleon::operator!= meant to not be accessable");
+    return true;
+}
+
+G4double G4StatMFMacroBiNucleon::CalcMeanMultiplicity(const G4double FreeVol, 
+						      const G4double mu, 
+						      const G4double nu, 
+						      const G4double T)
+{
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+    
+  const G4double BindingE = G4NucleiProperties::GetBindingEnergy(theA,1); 
+  //old value was 2.796*MeV
+  G4double exponent = (BindingE + theA*(mu+nu*theZARatio) - 
+		       G4StatMFParameters::GetCoulomb()*theZARatio*theZARatio*theA
+		       *G4Pow::GetInstance()->Z23(theA))/T;
+
+  // To avoid numerical problems
+  if (exponent < -300.0) exponent = -300.0;
+  else if (exponent > 300.0) exponent = 300.0;
+
+  _MeanMultiplicity = (degeneracy*FreeVol*theA*std::sqrt((G4double)theA)/lambda3)*
+    G4Exp(exponent);
+			 
+  return _MeanMultiplicity;
+}
+
+G4double G4StatMFMacroBiNucleon::CalcEnergy(const G4double T)
+{
+  _Energy  = -G4NucleiProperties::GetBindingEnergy(theA,1) + 
+    G4StatMFParameters::GetCoulomb() * theZARatio * theZARatio 
+    * theA*G4Pow::GetInstance()->Z23(theA) + 1.5*T;
+							
+  return _Energy;				
+}
+
+G4double G4StatMFMacroBiNucleon::CalcEntropy(const G4double T, const G4double FreeVol)
+{
+  G4double Entropy = 0.0;
+  if (_MeanMultiplicity > 0.0) {
+    G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+    G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+    // Is this formula correct?
+    Entropy = _MeanMultiplicity*(2.5+G4Log(3.0*theA*std::sqrt((G4double)theA)*FreeVol
+					     /(lambda3*_MeanMultiplicity)));
+  }
+  return Entropy;
+}

--- a/Multifragmentation/src/G4StatMFMacroCanonical.cc
+++ b/Multifragmentation/src/G4StatMFMacroCanonical.cc
@@ -1,0 +1,279 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// by V. Lara
+// --------------------------------------------------------------------
+//
+// Modified:
+// 25.07.08 I.Pshenichnov (in collaboration with Alexander Botvina and Igor 
+//          Mishustin (FIAS, Frankfurt, INR, Moscow and Kurchatov Institute, 
+//          Moscow, pshenich@fias.uni-frankfurt.de) fixed infinite loop for 
+//          a fagment with Z=A; fixed memory leak
+
+#include "G4StatMFMacroCanonical.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Pow.hh"
+
+// constructor
+G4StatMFMacroCanonical::G4StatMFMacroCanonical(const G4Fragment & theFragment) 
+{
+
+  // Get memory for clusters
+  _theClusters.push_back(new G4StatMFMacroNucleon);              // Size 1
+  _theClusters.push_back(new G4StatMFMacroBiNucleon);            // Size 2
+  _theClusters.push_back(new G4StatMFMacroTriNucleon);           // Size 3
+  _theClusters.push_back(new G4StatMFMacroTetraNucleon);         // Size 4
+  for (G4int i = 4; i < theFragment.GetA_asInt(); i++)   
+    _theClusters.push_back(new G4StatMFMacroMultiNucleon(i+1)); // Size 5 ... A
+  
+  // Perform class initialization
+  Initialize(theFragment);
+    
+}
+
+// destructor
+G4StatMFMacroCanonical::~G4StatMFMacroCanonical() 
+{
+  // garbage collection
+  if (!_theClusters.empty()) 
+    {
+      std::for_each(_theClusters.begin(),_theClusters.end(),DeleteFragment());
+    }
+}
+
+// Initialization method
+void G4StatMFMacroCanonical::Initialize(const G4Fragment & theFragment) 
+{
+  
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  G4double x = 1.0 - 2.0*Z/G4double(A);
+  G4Pow* g4calc = G4Pow::GetInstance();
+  
+  // Free Internal energy at T = 0
+  __FreeInternalE0 = A*( -G4StatMFParameters::GetE0() +     // Volume term (for T = 0)
+			 G4StatMFParameters::GetGamma0()*x*x) // Symmetry term
+    + G4StatMFParameters::GetBeta0()*g4calc->Z23(A) +   // Surface term (for T = 0)
+    0.6*elm_coupling*Z*Z/(G4StatMFParameters::Getr0()*     // Coulomb term 
+			  g4calc->Z13(A));
+  
+  CalculateTemperature(theFragment);
+  return;
+}
+
+void G4StatMFMacroCanonical::CalculateTemperature(const G4Fragment & theFragment)
+{
+  // Excitation Energy
+  G4double U = theFragment.GetExcitationEnergy();
+  
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  
+  // Fragment Multiplicity
+  G4double FragMult = std::max((1.0+(2.31/MeV)*(U/A - 3.5*MeV))*A/100.0, 2.0);
+
+  // Parameter Kappa
+  G4Pow* g4calc = G4Pow::GetInstance();
+  _Kappa = (1.0+elm_coupling*(g4calc->A13(FragMult)-1)/
+	    (G4StatMFParameters::Getr0()*g4calc->Z13(A)));
+  _Kappa = _Kappa*_Kappa*_Kappa - 1.0;
+	
+  G4StatMFMacroTemperature * theTemp = new	
+    G4StatMFMacroTemperature(A,Z,U,__FreeInternalE0,_Kappa,&_theClusters);
+  
+  __MeanTemperature = theTemp->CalcTemperature();
+  _ChemPotentialNu = theTemp->GetChemicalPotentialNu();
+  _ChemPotentialMu = theTemp->GetChemicalPotentialMu();
+  __MeanMultiplicity = theTemp->GetMeanMultiplicity();
+  __MeanEntropy = theTemp->GetEntropy();
+	
+  delete theTemp;			
+  
+  return;
+}
+
+// --------------------------------------------------------------------------
+
+G4StatMFChannel * G4StatMFMacroCanonical::ChooseAandZ(const G4Fragment &theFragment)
+// Calculate total fragments multiplicity, fragment atomic numbers and charges
+{
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  
+  std::vector<G4int> ANumbers(A);
+  
+  G4double Multiplicity = ChooseA(A,ANumbers);
+  
+  std::vector<G4int> FragmentsA;
+  
+  G4int i = 0;  
+  for (i = 0; i < A; i++) 
+    {
+      for (G4int j = 0; j < ANumbers[i]; j++) FragmentsA.push_back(i+1);
+    }
+  
+  // Sort fragments in decreasing order
+  G4int im = 0;
+  for (G4int j = 0; j < Multiplicity; j++) 
+    {
+      G4int FragmentsAMax = 0;
+      im = j;
+      for (i = j; i < Multiplicity; i++) 
+	{
+	  if (FragmentsA[i] <= FragmentsAMax) { continue; }
+	  else 
+	    {
+	      im = i;
+	      FragmentsAMax = FragmentsA[im];
+	    }
+	}	
+      if (im != j) 
+	{
+	  FragmentsA[im] = FragmentsA[j];
+	  FragmentsA[j]  = FragmentsAMax;
+	}
+    }
+  return ChooseZ(Z,FragmentsA);
+}
+
+G4double G4StatMFMacroCanonical::ChooseA(G4int A, std::vector<G4int> & ANumbers)
+  // Determines fragments multiplicities and compute total fragment multiplicity
+{
+  G4double multiplicity = 0.0;
+  G4int i;
+    
+  std::vector<G4double> AcumMultiplicity;
+  AcumMultiplicity.reserve(A);
+
+  AcumMultiplicity.push_back((*(_theClusters.begin()))->GetMeanMultiplicity());
+  for (std::vector<G4VStatMFMacroCluster*>::iterator it = _theClusters.begin()+1;
+       it != _theClusters.end(); ++it)
+    {
+      AcumMultiplicity.push_back((*it)->GetMeanMultiplicity()+AcumMultiplicity.back());
+    }
+  
+  G4int CheckA;
+  do {
+    CheckA = -1;
+    G4int SumA = 0;
+    G4int ThisOne = 0;
+    multiplicity = 0.0;
+    for (i = 0; i < A; i++) ANumbers[i] = 0;
+    do {
+      G4double RandNumber = G4UniformRand()*__MeanMultiplicity;
+      for (i = 0; i < A; i++) {
+	if (RandNumber < AcumMultiplicity[i]) {
+	  ThisOne = i;
+	  break;
+	}
+      }
+      multiplicity++;
+      ANumbers[ThisOne] = ANumbers[ThisOne]+1;
+      SumA += ThisOne+1;
+      CheckA = A - SumA;
+      
+      // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+    } while (CheckA > 0);
+    
+    // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  } while (CheckA < 0 || std::abs(__MeanMultiplicity - multiplicity) > std::sqrt(__MeanMultiplicity) + 0.5);
+  
+  return multiplicity;
+}
+
+G4StatMFChannel * G4StatMFMacroCanonical::ChooseZ(G4int & Z, 
+						  std::vector<G4int> & FragmentsA)
+    // 
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  std::vector<G4int> FragmentsZ;
+  
+  G4int DeltaZ = 0;
+  G4double CP =  G4StatMFParameters::GetCoulomb();
+  G4int multiplicity = FragmentsA.size();
+  
+  do {
+    FragmentsZ.clear();
+    G4int SumZ = 0;
+    for (G4int i = 0; i < multiplicity; i++) 
+      {
+	G4int A = FragmentsA[i];
+	if (A <= 1) 
+	  {
+	    G4double RandNumber = G4UniformRand();
+	    if (RandNumber < (*_theClusters.begin())->GetZARatio()) 
+	      {
+		FragmentsZ.push_back(1);
+		SumZ += FragmentsZ[i];
+	      } 
+	    else FragmentsZ.push_back(0);
+	  } 
+	else 
+	  {
+	    G4double RandZ;
+	    G4double CC = 8.0*G4StatMFParameters::GetGamma0()
+	      + 2*CP*g4calc->Z23(FragmentsA[i]);
+	    G4double ZMean;
+	    if (FragmentsA[i] > 1 && FragmentsA[i] < 5) { ZMean = 0.5*FragmentsA[i]; }
+	    else {
+	      ZMean = FragmentsA[i]*(4.0*G4StatMFParameters::GetGamma0()
+				     + _ChemPotentialNu)/CC; 
+	    }
+	    G4double ZDispersion = std::sqrt(FragmentsA[i]*__MeanTemperature/CC);
+	    G4int z;
+	    do 
+	      {
+		RandZ = G4RandGauss::shoot(ZMean,ZDispersion);
+		z = G4lrint(RandZ+0.5);
+		// Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+	      } while (z < 0 || z > A);
+	    FragmentsZ.push_back(z);
+	    SumZ += z;
+	  }
+      }
+    DeltaZ = Z - SumZ;
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  } while (std::abs(DeltaZ) > 1);
+    
+  // DeltaZ can be 0, 1 or -1
+  G4int idx = 0;
+  if (DeltaZ < 0.0)
+    {
+      while (FragmentsZ[idx] < 1) { ++idx; }
+    }
+  FragmentsZ[idx] += DeltaZ;
+  
+  G4StatMFChannel * theChannel = new G4StatMFChannel;
+  for (G4int i = multiplicity-1; i >= 0; i--) 
+    {
+      theChannel->CreateFragment(FragmentsA[i],FragmentsZ[i]);
+    }
+ 
+  return theChannel;
+}

--- a/Multifragmentation/src/G4StatMFMacroChemicalPotential.cc
+++ b/Multifragmentation/src/G4StatMFMacroChemicalPotential.cc
@@ -1,0 +1,144 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMacroChemicalPotential.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4Pow.hh"
+
+// operators definitions
+G4StatMFMacroChemicalPotential & 
+G4StatMFMacroChemicalPotential::operator=(const G4StatMFMacroChemicalPotential & ) 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroChemicalPotential::operator= meant to not be accessable");
+    return *this;
+}
+
+G4bool G4StatMFMacroChemicalPotential::operator==(const G4StatMFMacroChemicalPotential & ) const 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroChemicalPotential::operator== meant to not be accessable");
+    return false;
+}
+
+
+G4bool G4StatMFMacroChemicalPotential::operator!=(const G4StatMFMacroChemicalPotential & ) const 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroChemicalPotential::operator!= meant to not be accessable");
+    return true;
+}
+
+G4double G4StatMFMacroChemicalPotential::CalcChemicalPotentialNu(void) 
+//	Calculate Chemical potential \nu
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double CP = G4StatMFParameters::GetCoulomb();
+
+  // Initial value for _ChemPotentialNu	
+  _ChemPotentialNu = (theZ/theA)*(8.0*G4StatMFParameters::GetGamma0()
+				  +2.0*CP*g4calc->Z23(theA))
+    - 4.0*G4StatMFParameters::GetGamma0();
+		
+  G4double ChemPa = _ChemPotentialNu;
+  G4double ChemPb = 0.5*_ChemPotentialNu;
+    
+  G4double fChemPa = this->operator()(ChemPa); 
+  G4double fChemPb = this->operator()(ChemPb); 
+
+  if (fChemPa*fChemPb > 0.0) {    
+    // bracketing the solution
+    if (fChemPa < 0.0) {
+      do {
+	ChemPb -= 1.5*std::abs(ChemPb-ChemPa);
+	fChemPb = this->operator()(ChemPb);   
+	// Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+      } while (fChemPb < 0.0);
+    } else {
+      do {
+	ChemPb += 1.5*std::abs(ChemPb-ChemPa);
+	fChemPb = this->operator()(ChemPb);
+	// Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+      } while (fChemPb > 0.0);
+    }
+  }
+
+  G4Solver<G4StatMFMacroChemicalPotential> * theSolver =
+    new G4Solver<G4StatMFMacroChemicalPotential>(100,1.e-4);
+  theSolver->SetIntervalLimits(ChemPa,ChemPb);
+  //    if (!theSolver->Crenshaw(*this)) 
+  if (!theSolver->Brent(*this)){
+    G4cout <<"G4StatMFMacroChemicalPotential:"<<" ChemPa="<<ChemPa
+	   <<" ChemPb="<<ChemPb<< G4endl;
+    G4cout <<"G4StatMFMacroChemicalPotential:"<<" fChemPa="<<fChemPa
+	   <<" fChemPb="<<fChemPb<< G4endl;
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroChemicalPotential::CalcChemicalPotentialNu: I couldn't find the root.");
+  }
+  _ChemPotentialNu = theSolver->GetRoot();
+  delete theSolver;
+  return _ChemPotentialNu;
+}
+
+
+
+G4double G4StatMFMacroChemicalPotential::CalcMeanZ(const G4double nu)
+{
+  std::vector<G4VStatMFMacroCluster*>::iterator i;
+  for (i= _theClusters->begin()+1; i != _theClusters->end(); ++i) 
+    { 
+      (*i)->CalcZARatio(nu);
+    }
+  CalcChemicalPotentialMu(nu);
+  // This is important, the Z over A ratio for proton and neutron depends on the 
+  // chemical potential Mu, while for the first guess for Chemical potential mu 
+  // some values of Z over A ratio. This is the reason for that.
+  (*_theClusters->begin())->CalcZARatio(nu);
+  
+  G4double MeanZ = 0.0;
+  G4int n = 1;
+  for (i = _theClusters->begin(); i != _theClusters->end(); ++i)
+    {
+      MeanZ += (n++) * (*i)->GetZARatio() * (*i)->GetMeanMultiplicity(); 
+    }
+  return MeanZ;
+}
+
+void G4StatMFMacroChemicalPotential::CalcChemicalPotentialMu(const G4double nu)
+//	Calculate Chemical potential \mu
+// For that is necesary to calculate mean multiplicities
+{
+  G4StatMFMacroMultiplicity * theMultip = new
+    G4StatMFMacroMultiplicity(theA,_Kappa,_MeanTemperature,nu,_theClusters);
+  
+  _ChemPotentialMu = theMultip->CalcChemicalPotentialMu();
+  _MeanMultiplicity = theMultip->GetMeanMultiplicity();
+  
+  delete theMultip;
+  
+  return; 
+}

--- a/Multifragmentation/src/G4StatMFMacroMultiNucleon.cc
+++ b/Multifragmentation/src/G4StatMFMacroMultiNucleon.cc
@@ -1,0 +1,160 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+//
+// Modified:
+// 25.07.08 I.Pshenichnov (in collaboration with Alexander Botvina and Igor 
+//          Mishustin (FIAS, Frankfurt, INR, Moscow and Kurchatov Institute, 
+//          Moscow, pshenich@fias.uni-frankfurt.de) fixed computation of the 
+//          symmetry energy 
+
+#include "G4StatMFMacroMultiNucleon.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+#include "G4Pow.hh"
+
+// Default constructor
+G4StatMFMacroMultiNucleon::
+G4StatMFMacroMultiNucleon() :
+    G4VStatMFMacroCluster(0)  // Beacuse the def. constr. of base class is private
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiNucleon::default_constructor meant to not be accessable");
+}
+
+// Copy constructor
+G4StatMFMacroMultiNucleon::
+G4StatMFMacroMultiNucleon(const G4StatMFMacroMultiNucleon & ) :
+    G4VStatMFMacroCluster(0)  // Beacuse the def. constr. of base class is private
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiNucleon::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4StatMFMacroMultiNucleon & G4StatMFMacroMultiNucleon::
+operator=(const G4StatMFMacroMultiNucleon & ) 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiNucleon::operator= meant to not be accessable");
+    return *this;
+}
+
+G4bool G4StatMFMacroMultiNucleon::operator==(const G4StatMFMacroMultiNucleon & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiNucleon::operator== meant to not be accessable");
+    return false;
+}
+ 
+G4bool G4StatMFMacroMultiNucleon::operator!=(const G4StatMFMacroMultiNucleon & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiNucleon::operator!= meant to not be accessable");
+    return true;
+}
+
+G4double G4StatMFMacroMultiNucleon::CalcMeanMultiplicity(const G4double FreeVol, 
+							 const G4double mu,
+							 const G4double nu, 
+							 const G4double T)
+{
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);	
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double A23 = g4calc->Z23(theA);
+	
+  G4double exponent = (mu + nu*theZARatio+ G4StatMFParameters::GetE0() 
+		       + T*T/_InvLevelDensity 
+		       - G4StatMFParameters::GetGamma0()*(1.0 - 2.0*theZARatio)*
+		       (1.0 - 2.0*theZARatio))*theA
+    - G4StatMFParameters::Beta(T)*A23 
+    - G4StatMFParameters::GetCoulomb()*theZARatio*theZARatio*A23*theA;
+	
+  exponent /= T;
+	
+  if (exponent > 30.0) exponent = 30.0;
+	
+  _MeanMultiplicity = std::max((FreeVol * theA * std::sqrt((G4double)theA)/lambda3) *
+			       G4Exp(exponent),1.0e-30);
+  return _MeanMultiplicity;	
+}
+
+G4double G4StatMFMacroMultiNucleon::CalcZARatio(const G4double nu)
+{
+  G4double den = 8*G4StatMFParameters::GetGamma0() 
+    + 2*G4StatMFParameters::GetCoulomb()*G4Pow::GetInstance()->Z23(theA);
+  theZARatio = (4.0*G4StatMFParameters::GetGamma0()+nu)/den;
+  return theZARatio;
+}
+
+G4double G4StatMFMacroMultiNucleon::CalcEnergy(const G4double T)
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double A23 = g4calc->Z23(theA);
+
+  // Volume term 
+  G4double EVol = theA * (T*T/_InvLevelDensity - G4StatMFParameters::GetE0());
+	
+  // Symmetry term
+  G4double ESym = theA * G4StatMFParameters::GetGamma0() 
+    *(1. - 2.* theZARatio) * (1. - 2.* theZARatio);
+	
+  // Surface term
+  G4double ESurf = A23*(G4StatMFParameters::Beta(T) - T*G4StatMFParameters::DBetaDT(T));
+ 
+  // Coulomb term
+  G4double ECoul = G4StatMFParameters::GetCoulomb()*A23*theA*theZARatio*theZARatio;
+	
+  // Translational term
+  G4double ETrans = 1.5*T;
+  return _Energy = EVol + ESurf + ECoul + ETrans + ESym;
+}
+
+G4double G4StatMFMacroMultiNucleon::CalcEntropy(const G4double T, 
+						const G4double FreeVol)
+{
+  G4double Entropy = 0.0;
+  if (_MeanMultiplicity > 0.0) {
+
+    G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+    G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+    // Volume term
+    G4double SV = 2.0*theA*T/_InvLevelDensity;
+		
+    // Surface term
+    G4double SS = -G4StatMFParameters::DBetaDT(T)*G4Pow::GetInstance()->Z23(theA);
+		
+    // Translational term
+    G4double ST = 2.5 + G4Log(FreeVol * std::sqrt((G4double)theA) * theA
+			      /(lambda3*_MeanMultiplicity));
+				
+    Entropy = _MeanMultiplicity*(SV + SS + ST);
+  }								
+  return Entropy;
+}

--- a/Multifragmentation/src/G4StatMFMacroMultiplicity.cc
+++ b/Multifragmentation/src/G4StatMFMacroMultiplicity.cc
@@ -1,0 +1,162 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+//
+// Modified:
+// 25.07.08 I.Pshenichnov (in collaboration with Alexander Botvina and Igor 
+//          Mishustin (FIAS, Frankfurt, INR, Moscow and Kurchatov Institute, 
+//          Moscow, pshenich@fias.uni-frankfurt.de) additional checks in
+//          solver of equation for the chemical potential
+
+#include "G4StatMFMacroMultiplicity.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4Pow.hh"
+
+// operators definitions
+G4StatMFMacroMultiplicity & 
+G4StatMFMacroMultiplicity::operator=(const G4StatMFMacroMultiplicity & ) 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiplicity::operator= meant to not be accessable");
+    return *this;
+}
+
+G4bool G4StatMFMacroMultiplicity::operator==(const G4StatMFMacroMultiplicity & ) const 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiplicity::operator== meant to not be accessable");
+    return false;
+}
+
+
+G4bool G4StatMFMacroMultiplicity::operator!=(const G4StatMFMacroMultiplicity & ) const 
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiplicity::operator!= meant to not be accessable");
+    return true;
+}
+
+G4double G4StatMFMacroMultiplicity::CalcChemicalPotentialMu(void) 
+    //	Calculate Chemical potential \mu
+    // For that is necesary to calculate mean multiplicities
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double CP = G4StatMFParameters::GetCoulomb();
+
+  // starting value for chemical potential \mu
+  // it is the derivative of F(T,V)-\nu*Z w.r.t. Af in Af=5
+  G4double ZA5 = _theClusters->operator[](4)->GetZARatio();
+  G4double ILD5 = _theClusters->operator[](4)->GetInvLevelDensity();
+  _ChemPotentialMu = -G4StatMFParameters::GetE0()-
+    _MeanTemperature*_MeanTemperature/ILD5 -
+    _ChemPotentialNu*ZA5 + 
+    G4StatMFParameters::GetGamma0()*(1.0-2.0*ZA5)*(1.0-2.0*ZA5) +
+    (2.0/3.0)*G4StatMFParameters::Beta(_MeanTemperature)/g4calc->Z13(5) +
+    (5.0/3.0)*CP*ZA5*ZA5*g4calc->Z23(5) -
+    1.5*_MeanTemperature/5.0;
+		
+  G4double ChemPa = _ChemPotentialMu;
+  if (ChemPa/_MeanTemperature > 10.0) ChemPa = 10.0*_MeanTemperature;
+  G4double ChemPb = ChemPa - 0.5*std::abs(ChemPa);
+ 
+  G4double fChemPa = this->operator()(ChemPa); 
+  G4double fChemPb = this->operator()(ChemPb); 
+     
+  // Set the precision level for locating the root. 
+  // If the root is inside this interval, then it's done! 
+  const G4double intervalWidth = 1.e-4;
+
+  // bracketing the solution
+  G4int iterations = 0;
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (fChemPa*fChemPb > 0.0 && iterations < 100) 
+    {
+      iterations++;
+      if (std::abs(fChemPa) <= std::abs(fChemPb)) 
+	{
+	  ChemPa += 0.6*(ChemPa-ChemPb);
+	  fChemPa = this->operator()(ChemPa);
+	} 
+      else 
+	{
+	  ChemPb += 0.6*(ChemPb-ChemPa);
+	  fChemPb = this->operator()(ChemPb);
+	}
+    }
+
+  if (fChemPa*fChemPb > 0.0) // the bracketing failed, complain 
+    {
+      G4cout <<"G4StatMFMacroMultiplicity:"<<" ChemPa="<<ChemPa
+	     <<" ChemPb="<<ChemPb<< G4endl;
+      G4cout <<"G4StatMFMacroMultiplicity:"<<" fChemPa="<<fChemPa
+	     <<" fChemPb="<<fChemPb<< G4endl;
+      throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiplicity::CalcChemicalPotentialMu: I couldn't bracket the root.");
+    }
+  else if (fChemPa*fChemPb < 0.0 && std::abs(ChemPa-ChemPb) > intervalWidth)
+    {	
+    G4Solver<G4StatMFMacroMultiplicity> * theSolver = 
+      new G4Solver<G4StatMFMacroMultiplicity>(100,intervalWidth);
+    theSolver->SetIntervalLimits(ChemPa,ChemPb);
+    //    if (!theSolver->Crenshaw(*this)) 
+    if (!theSolver->Brent(*this)) 
+    {
+      G4cout <<"G4StatMFMacroMultiplicity:"<<" ChemPa="<<ChemPa
+	     <<" ChemPb="<<ChemPb<< G4endl;
+      throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroMultiplicity::CalcChemicalPotentialMu: I couldn't find the root.");
+    }
+    _ChemPotentialMu = theSolver->GetRoot();
+    delete theSolver;
+    }
+  else // the root is within the interval, which is shorter then the precision level - all done 
+    {
+     _ChemPotentialMu = ChemPa;
+    }
+
+  return _ChemPotentialMu;
+}
+
+G4double G4StatMFMacroMultiplicity::CalcMeanA(const G4double mu)
+{
+  G4double r0 = G4StatMFParameters::Getr0(); 
+  G4double V0 = (4.0/3.0)*pi*theA*r0*r0*r0;
+
+  G4double MeanA = 0.0;
+	
+  _MeanMultiplicity = 0.0;
+	
+  G4int n = 1;
+  for (std::vector<G4VStatMFMacroCluster*>::iterator i = _theClusters->begin(); 
+      i != _theClusters->end(); ++i) 
+   {
+     G4double multip = (*i)->CalcMeanMultiplicity(V0*_Kappa,mu,_ChemPotentialNu,
+						  _MeanTemperature);
+     MeanA += multip*(n++);
+     _MeanMultiplicity += multip;
+   }
+
+  return MeanA;
+}

--- a/Multifragmentation/src/G4StatMFMacroNucleon.cc
+++ b/Multifragmentation/src/G4StatMFMacroNucleon.cc
@@ -1,0 +1,101 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMacroNucleon.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+
+G4StatMFMacroNucleon::G4StatMFMacroNucleon() 
+  : G4VStatMFMacroCluster(1), _NeutronMeanMultiplicity(0.0),
+    _ProtonMeanMultiplicity(0.0)
+{}
+
+G4StatMFMacroNucleon::~G4StatMFMacroNucleon() 
+{}
+	
+G4double 
+G4StatMFMacroNucleon::CalcMeanMultiplicity(const G4double FreeVol, 
+					   const G4double mu, 
+					   const G4double nu, const G4double T)
+{
+  if (T <= 0.0) {
+    throw G4HadronicException(__FILE__, __LINE__, 
+			      "G4StatMFMacroNucleon::CalcMeanMultiplicity: Temperature less or equal 0");
+  }
+
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+	
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+	
+  static const G4double degeneracy = 2.0;
+	
+  G4double exponent_proton = (mu + nu - G4StatMFParameters::GetCoulomb())/T;
+  G4double exponent_neutron = mu/T;
+
+  if (exponent_neutron > 300.0) exponent_neutron = 300.0;
+  if (exponent_proton > 300.0) exponent_proton = 300.0;
+
+  _NeutronMeanMultiplicity = 
+    (degeneracy*FreeVol/lambda3)*G4Exp(exponent_neutron);
+	
+  _ProtonMeanMultiplicity = 
+    (degeneracy*FreeVol/lambda3)*G4Exp(exponent_proton);
+
+  return _MeanMultiplicity = _NeutronMeanMultiplicity + _ProtonMeanMultiplicity;
+}
+
+
+G4double G4StatMFMacroNucleon::CalcEnergy(const G4double T)
+{
+  return _Energy = G4StatMFParameters::GetCoulomb()*theZARatio*theZARatio + 1.5*T;
+}
+
+G4double 
+G4StatMFMacroNucleon::CalcEntropy(const G4double T, const G4double FreeVol)
+{
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+
+  G4double NeutronEntropy = 0.0;
+  if (_NeutronMeanMultiplicity > 0.0)
+    NeutronEntropy = _NeutronMeanMultiplicity*(2.5+G4Log(2*theA*FreeVol/
+			    (lambda3*_NeutronMeanMultiplicity)));
+				
+  G4double ProtonEntropy = 0.0;
+  if (_ProtonMeanMultiplicity > 0.0)
+    ProtonEntropy = _ProtonMeanMultiplicity*(2.5+G4Log(2*theA*FreeVol/
+		    (lambda3*_ProtonMeanMultiplicity)));
+				
+  return NeutronEntropy+ProtonEntropy;
+}
+

--- a/Multifragmentation/src/G4StatMFMacroTemperature.cc
+++ b/Multifragmentation/src/G4StatMFMacroTemperature.cc
@@ -1,0 +1,200 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+//
+// Modified:
+// 25.07.08 I.Pshenichnov (in collaboration with Alexander Botvina and Igor 
+//          Mishustin (FIAS, Frankfurt, INR, Moscow and Kurchatov Institute, 
+//          Moscow, pshenich@fias.uni-frankfurt.de) make algorithm closer to
+//          original MF model
+// 16.04.10 V.Ivanchenko improved logic of solving equation for tempetature
+//          to protect code from rare unwanted exception; moved constructor 
+//          and destructor to source  
+// 28.10.10 V.Ivanchenko defined members in constructor and cleaned up
+
+#include "G4StatMFMacroTemperature.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Pow.hh"
+
+G4StatMFMacroTemperature::G4StatMFMacroTemperature(const G4double anA, const G4double aZ, 
+  const G4double ExEnergy, const G4double FreeE0, const G4double kappa, 
+  std::vector<G4VStatMFMacroCluster*> * ClusterVector) :
+  theA(anA),
+  theZ(aZ),
+  _ExEnergy(ExEnergy),
+  _FreeInternalE0(FreeE0),
+  _Kappa(kappa),
+  _MeanMultiplicity(0.0),
+  _MeanTemperature(0.0),
+  _ChemPotentialMu(0.0),
+  _ChemPotentialNu(0.0),
+  _MeanEntropy(0.0),
+  _theClusters(ClusterVector) 
+{}
+	
+G4StatMFMacroTemperature::~G4StatMFMacroTemperature() 
+{}
+
+G4double G4StatMFMacroTemperature::CalcTemperature(void) 
+{
+  // Inital guess for the interval of the ensemble temperature values
+  G4double Ta = 0.5; 
+  G4double Tb = std::max(std::sqrt(_ExEnergy/(theA*0.12)),0.01*MeV);
+    
+  G4double fTa = this->operator()(Ta); 
+  G4double fTb = this->operator()(Tb); 
+
+  // Bracketing the solution
+  // T should be greater than 0.
+  // The interval is [Ta,Tb]
+  // We start with a value for Ta = 0.5 MeV
+  // it should be enough to have fTa > 0 If it isn't 
+  // the case, we decrease Ta. But carefully, because 
+  // fTa growes very fast when Ta is near 0 and we could have
+  // an overflow.
+
+  G4int iterations = 0;  
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (fTa < 0.0 && ++iterations < 10) {
+    Ta -= 0.5*Ta;
+    fTa = this->operator()(Ta);
+  }
+  // Usually, fTb will be less than 0, but if it is not the case: 
+  iterations = 0;  
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (fTa*fTb > 0.0 && iterations++ < 10) {
+    Tb += 2.*std::fabs(Tb-Ta);
+    fTb = this->operator()(Tb);
+  }
+	
+  if (fTa*fTb > 0.0) {
+    G4cerr <<"G4StatMFMacroTemperature:"<<" Ta="<<Ta<<" Tb="<<Tb<< G4endl;
+    G4cerr <<"G4StatMFMacroTemperature:"<<" fTa="<<fTa<<" fTb="<<fTb<< G4endl;
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroTemperature::CalcTemperature: I couldn't bracket the solution.");
+  }
+
+  G4Solver<G4StatMFMacroTemperature> * theSolver = 
+    new G4Solver<G4StatMFMacroTemperature>(100,1.e-4);
+  theSolver->SetIntervalLimits(Ta,Tb);
+  if (!theSolver->Crenshaw(*this)){ 
+    G4cout <<"G4StatMFMacroTemperature, Crenshaw method failed:"<<" Ta="
+	   <<Ta<<" Tb="<<Tb<< G4endl;
+    G4cout <<"G4StatMFMacroTemperature, Crenshaw method failed:"<<" fTa="
+	   <<fTa<<" fTb="<<fTb<< G4endl;
+  }
+  _MeanTemperature = theSolver->GetRoot();
+  G4double FunctionValureAtRoot =  this->operator()(_MeanTemperature);
+  delete  theSolver;
+
+  // Verify if the root is found and it is indeed within the physical domain, 
+  // say, between 1 and 50 MeV, otherwise try Brent method:
+  if (std::fabs(FunctionValureAtRoot) > 5.e-2) {
+    if (_MeanTemperature < 1. || _MeanTemperature > 50.) {
+      G4cout << "Crenshaw method failed; function = " << FunctionValureAtRoot 
+	     << " solution? = " << _MeanTemperature << " MeV " << G4endl;
+      G4Solver<G4StatMFMacroTemperature> * theSolverBrent = 
+	new G4Solver<G4StatMFMacroTemperature>(200,1.e-3);
+      theSolverBrent->SetIntervalLimits(Ta,Tb);
+      if (!theSolverBrent->Brent(*this)){
+	G4cout <<"G4StatMFMacroTemperature, Brent method failed:"
+	       <<" Ta="<<Ta<<" Tb="<<Tb<< G4endl;
+	G4cout <<"G4StatMFMacroTemperature, Brent method failed:"
+	       <<" fTa="<<fTa<<" fTb="<<fTb<< G4endl; 
+	throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroTemperature::CalcTemperature: I couldn't find the root with any method.");
+      }
+
+      _MeanTemperature = theSolverBrent->GetRoot();
+      FunctionValureAtRoot =  this->operator()(_MeanTemperature);
+      delete theSolverBrent;
+    }
+    if (std::abs(FunctionValureAtRoot) > 5.e-2) {
+      G4cout << "Brent method failed; function = " << FunctionValureAtRoot 
+	     << " solution? = " << _MeanTemperature << " MeV " << G4endl;
+      throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMacroTemperature::CalcTemperature: I couldn't find the root with any method.");
+    }
+  }
+  //G4cout << "G4StatMFMacroTemperature::CalcTemperature: function = " 
+  //<< FunctionValureAtRoot 
+  //	   << " T(MeV)= " << _MeanTemperature << G4endl;
+  return _MeanTemperature;
+}
+
+G4double G4StatMFMacroTemperature::FragsExcitEnergy(const G4double T)
+// Calculates excitation energy per nucleon and summed fragment 
+// multiplicity and entropy
+{
+  // Model Parameters
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double R0 = G4StatMFParameters::Getr0()*g4calc->Z13(theA);
+  G4double R = R0*g4calc->A13(1.0+G4StatMFParameters::GetKappaCoulomb());
+  G4double FreeVol = _Kappa*(4.*pi/3.)*R0*R0*R0; 
+ 
+  // Calculate Chemical potentials
+  CalcChemicalPotentialNu(T);
+
+
+  // Average total fragment energy
+  G4double AverageEnergy = 0.0;
+  std::vector<G4VStatMFMacroCluster*>::iterator i;
+  for (i =  _theClusters->begin(); i != _theClusters->end(); ++i) 
+    {
+      AverageEnergy += (*i)->GetMeanMultiplicity() * (*i)->CalcEnergy(T);
+    }
+    
+  // Add Coulomb energy			
+  AverageEnergy += 0.6*elm_coupling*theZ*theZ/R;		
+    
+  // Calculate mean entropy
+  _MeanEntropy = 0.0;
+  for (i = _theClusters->begin(); i != _theClusters->end(); ++i) 
+    {
+      _MeanEntropy += (*i)->CalcEntropy(T,FreeVol);	
+    }
+
+  // Excitation energy per nucleon
+  return AverageEnergy - _FreeInternalE0;
+}
+
+void G4StatMFMacroTemperature::CalcChemicalPotentialNu(const G4double T)
+// Calculates the chemical potential \nu 
+{
+  G4StatMFMacroChemicalPotential * theChemPot = new
+    G4StatMFMacroChemicalPotential(theA,theZ,_Kappa,T,_theClusters);
+
+  _ChemPotentialNu = theChemPot->CalcChemicalPotentialNu();
+  _ChemPotentialMu = theChemPot->GetChemicalPotentialMu();
+  _MeanMultiplicity = theChemPot->GetMeanMultiplicity();		
+  delete theChemPot;
+		    
+  return;
+}
+
+

--- a/Multifragmentation/src/G4StatMFMacroTetraNucleon.cc
+++ b/Multifragmentation/src/G4StatMFMacroTetraNucleon.cc
@@ -1,0 +1,90 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMacroTetraNucleon.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+#include "G4Pow.hh"
+
+G4StatMFMacroTetraNucleon::G4StatMFMacroTetraNucleon() 
+  : G4VStatMFMacroCluster(4) 
+{}
+
+G4StatMFMacroTetraNucleon::~G4StatMFMacroTetraNucleon() 
+{}
+
+G4double 
+G4StatMFMacroTetraNucleon::CalcMeanMultiplicity(const G4double FreeVol, 
+						const G4double mu, 
+						const G4double nu, 
+						const G4double T)
+{
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+  static const G4double degeneracy = 1;  // He4
+
+  //old value was 30.11*MeV
+  G4double BindingE = G4NucleiProperties::GetBindingEnergy(theA,2); 
+	
+  G4double exponent = (BindingE + theA*(mu+nu*theZARatio+T*T/_InvLevelDensity) 
+		       - G4StatMFParameters::GetCoulomb()*theZARatio*theZARatio*
+		       theA*G4Pow::GetInstance()->Z23(theA))/T;
+  if (exponent > 300.0) exponent = 300.0;
+    
+  _MeanMultiplicity = ( degeneracy*FreeVol*theA*std::sqrt((G4double)theA)/lambda3)* 
+    G4Exp(exponent);
+			 
+  return _MeanMultiplicity;	
+}
+
+G4double G4StatMFMacroTetraNucleon::CalcEnergy(const G4double T)
+{
+  return _Energy = -G4NucleiProperties::GetBindingEnergy(theA,2) + 
+    G4StatMFParameters::GetCoulomb() * theZARatio * theZARatio * 
+    theA*G4Pow::GetInstance()->Z23(theA) +
+    1.5 * T + theA * T*T/_InvLevelDensity;	
+}
+
+G4double 
+G4StatMFMacroTetraNucleon::CalcEntropy(const G4double T, 
+				       const G4double FreeVol)
+{
+  G4double Entropy = 0.0;
+  if (_MeanMultiplicity > 0.0) {
+    G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+    G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+    Entropy = _MeanMultiplicity*(2.5 + G4Log(8*FreeVol/(lambda3*_MeanMultiplicity)))+ 
+      8.0*T/_InvLevelDensity;
+  }		
+  return Entropy;
+}

--- a/Multifragmentation/src/G4StatMFMacroTriNucleon.cc
+++ b/Multifragmentation/src/G4StatMFMacroTriNucleon.cc
@@ -1,0 +1,89 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMacroTriNucleon.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+#include "G4Pow.hh"
+
+G4StatMFMacroTriNucleon::G4StatMFMacroTriNucleon() 
+  : G4VStatMFMacroCluster(3) 
+{}
+
+G4StatMFMacroTriNucleon::~G4StatMFMacroTriNucleon() 
+{}
+
+G4double 
+G4StatMFMacroTriNucleon::CalcMeanMultiplicity(const G4double FreeVol, 
+					      const G4double mu, 
+					      const G4double nu, 
+					      const G4double T)
+{
+  G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+  G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+  static const G4double degeneracy = 4.0;  // H3 + He3
+
+  // old value was 9.224*MeV
+  G4double BindingE = G4NucleiProperties::GetBindingEnergy(theA,1); 
+  //	  + G4NucleiProperties::GetBindingEnergy(theA,2);
+
+  G4double exponent = (BindingE+ theA*(mu+nu*theZARatio) - 
+		       G4StatMFParameters::GetCoulomb()*theZARatio*theZARatio
+		       *theA*G4Pow::GetInstance()->Z23(theA))/T;
+  if (exponent > 300.0) exponent = 300.0;
+
+  _MeanMultiplicity = (degeneracy*FreeVol*theA*std::sqrt((G4double)theA)/lambda3)*
+    G4Exp(exponent);
+			 
+  return _MeanMultiplicity;
+}
+
+G4double G4StatMFMacroTriNucleon::CalcEnergy(const G4double T)
+{
+  return _Energy  = -G4NucleiProperties::GetBindingEnergy(theA,1) + 
+    G4StatMFParameters::GetCoulomb() * theZARatio * theZARatio 
+    * theA*G4Pow::GetInstance()->Z23(theA) + 1.5 * T;
+}
+
+G4double 
+G4StatMFMacroTriNucleon::CalcEntropy(const G4double T, const G4double FreeVol)
+{
+  G4double Entropy = 0.0;
+  if (_MeanMultiplicity > 0.0) {
+    G4double ThermalWaveLenght = 16.15*fermi/std::sqrt(T);
+    G4double lambda3 = ThermalWaveLenght*ThermalWaveLenght*ThermalWaveLenght;
+    Entropy = _MeanMultiplicity*(2.5 + G4Log((4*theA)*std::sqrt((G4double)theA)
+					     *FreeVol/(lambda3*_MeanMultiplicity)));
+  }				
+  return Entropy;
+}

--- a/Multifragmentation/src/G4StatMFMicroCanonical.cc
+++ b/Multifragmentation/src/G4StatMFMicroCanonical.cc
@@ -1,0 +1,269 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include <numeric>
+
+#include "G4StatMFMicroCanonical.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4HadronicException.hh"
+#include "G4Pow.hh"
+
+// constructor
+G4StatMFMicroCanonical::G4StatMFMicroCanonical(G4Fragment const & theFragment) 
+{
+  // Perform class initialization
+  Initialize(theFragment);
+}
+
+// destructor
+G4StatMFMicroCanonical::~G4StatMFMicroCanonical() 
+{
+  // garbage collection
+  if (!_ThePartitionManagerVector.empty()) {
+    std::for_each(_ThePartitionManagerVector.begin(),
+		    _ThePartitionManagerVector.end(),
+		    DeleteFragment());
+  }
+}
+
+void G4StatMFMicroCanonical::Initialize(const G4Fragment & theFragment) 
+{
+  
+  std::vector<G4StatMFMicroManager*>::iterator it;
+
+  // Excitation Energy 
+  G4double U = theFragment.GetExcitationEnergy();
+
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  G4double x = 1.0 - 2.0*Z/G4double(A);
+  G4Pow* g4calc = G4Pow::GetInstance();
+    
+  // Configuration temperature
+  G4double TConfiguration = std::sqrt(8.0*U/G4double(A));
+  
+  // Free internal energy at Temperature T = 0
+  __FreeInternalE0 = A*( 
+			// Volume term (for T = 0)
+			-G4StatMFParameters::GetE0() +  
+			// Symmetry term
+			G4StatMFParameters::GetGamma0()*x*x 
+			) + 
+    // Surface term (for T = 0)
+    G4StatMFParameters::GetBeta0()*g4calc->Z23(A) + 
+    // Coulomb term 
+    elm_coupling*0.6*Z*Z/(G4StatMFParameters::Getr0()*g4calc->Z13(A));
+  
+  // Statistical weight
+  G4double W = 0.0;
+  
+  // Mean breakup multiplicity
+  __MeanMultiplicity = 0.0;
+  
+  // Mean channel temperature
+  __MeanTemperature = 0.0;
+  
+  // Mean channel entropy
+  __MeanEntropy = 0.0;
+  
+  // Calculate entropy of compound nucleus
+  G4double SCompoundNucleus = CalcEntropyOfCompoundNucleus(theFragment,TConfiguration);
+  
+  // Statistical weight of compound nucleus
+  _WCompoundNucleus = 1.0; 
+  
+  W += _WCompoundNucleus;
+    
+  // Maximal fragment multiplicity allowed in direct simulation
+  G4int MaxMult = G4StatMFMicroCanonical::MaxAllowedMultiplicity;
+  if (A > 110) MaxMult -= 1;
+  
+  for (G4int im = 2; im <= MaxMult; im++) {
+    G4StatMFMicroManager * aMicroManager = 
+      new G4StatMFMicroManager(theFragment,im,__FreeInternalE0,SCompoundNucleus);
+    _ThePartitionManagerVector.push_back(aMicroManager);
+  }
+  
+  // W is the total probability
+  W = std::accumulate(_ThePartitionManagerVector.begin(),
+		      _ThePartitionManagerVector.end(),
+		      W, SumProbabilities());
+  
+  // Normalization of statistical weights
+  for (it =  _ThePartitionManagerVector.begin(); it !=  _ThePartitionManagerVector.end(); ++it) 
+    {
+      (*it)->Normalize(W);
+    }
+
+  _WCompoundNucleus /= W;
+  
+  __MeanMultiplicity += 1.0 * _WCompoundNucleus;
+  __MeanTemperature += TConfiguration * _WCompoundNucleus;
+  __MeanEntropy += SCompoundNucleus * _WCompoundNucleus;
+  
+  for (it =  _ThePartitionManagerVector.begin(); it !=  _ThePartitionManagerVector.end(); ++it) 
+    {
+      __MeanMultiplicity += (*it)->GetMeanMultiplicity();
+      __MeanTemperature += (*it)->GetMeanTemperature();
+      __MeanEntropy += (*it)->GetMeanEntropy();
+    }
+  
+  return;
+}
+
+G4double G4StatMFMicroCanonical::CalcFreeInternalEnergy(const G4Fragment & theFragment, 
+							G4double T)
+{
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+  G4double A13 = G4Pow::GetInstance()->Z13(A);
+  
+  G4double InvLevelDensityPar = G4StatMFParameters::GetEpsilon0()
+    *(1.0 + 3.0/G4double(A-1));
+  
+  G4double VolumeTerm = (-G4StatMFParameters::GetE0()+T*T/InvLevelDensityPar)*A;
+  
+  G4double SymmetryTerm = G4StatMFParameters::GetGamma0()
+    *(A - 2*Z)*(A - 2*Z)/G4double(A);
+  
+  G4double SurfaceTerm = (G4StatMFParameters::Beta(T)
+			  - T*G4StatMFParameters::DBetaDT(T))*A13*A13;
+  
+  G4double CoulombTerm = elm_coupling*0.6*Z*Z/(G4StatMFParameters::Getr0()*A13);
+  
+  return VolumeTerm + SymmetryTerm + SurfaceTerm + CoulombTerm;
+}
+
+G4double 
+G4StatMFMicroCanonical::CalcEntropyOfCompoundNucleus(const G4Fragment & theFragment,
+						     G4double & TConf)
+  // Calculates Temperature and Entropy of compound nucleus
+{
+  G4int A = theFragment.GetA_asInt();
+  G4double U = theFragment.GetExcitationEnergy();
+  G4double A13 = G4Pow::GetInstance()->Z13(A);
+  
+  G4double Ta = std::max(std::sqrt(U/(0.125*A)),0.0012*MeV); 
+  G4double Tb = Ta;
+  
+  G4double ECompoundNucleus = CalcFreeInternalEnergy(theFragment,Ta);
+  G4double Da = (U+__FreeInternalE0-ECompoundNucleus)/U;
+  G4double Db = 0.0;
+    
+  G4double InvLevelDensity = CalcInvLevelDensity(A);
+  
+  // bracketing the solution
+  if (Da == 0.0) {
+    TConf = Ta;
+    return 2*Ta*A/InvLevelDensity - G4StatMFParameters::DBetaDT(Ta)*A13*A13;
+  } else if (Da < 0.0) {
+    do {
+      Tb -= 0.5*Tb;
+      ECompoundNucleus = CalcFreeInternalEnergy(theFragment,Tb);
+      Db = (U+__FreeInternalE0-ECompoundNucleus)/U;
+    } while (Db < 0.0);
+  } else {
+    do {
+      Tb += 0.5*Tb;
+      ECompoundNucleus = CalcFreeInternalEnergy(theFragment,Tb);
+      Db = (U+__FreeInternalE0-ECompoundNucleus)/U;
+    } while (Db > 0.0);
+  }
+  
+  G4double eps = 1.0e-14 * std::abs(Tb-Ta);
+  
+  for (G4int i = 0; i < 1000; i++) {
+    G4double Tc = (Ta+Tb)*0.5;
+    if (std::abs(Ta-Tb) <= eps) {
+      TConf = Tc;
+      return 2*Tc*A/InvLevelDensity - G4StatMFParameters::DBetaDT(Tc)*A13*A13;
+    }
+    ECompoundNucleus = CalcFreeInternalEnergy(theFragment,Tc);
+    G4double Dc = (U+__FreeInternalE0-ECompoundNucleus)/U;
+    
+    if (Dc == 0.0) {
+      TConf = Tc;
+      return 2*Tc*A/InvLevelDensity - G4StatMFParameters::DBetaDT(Tc)*A13*A13;
+    }
+    
+    if (Da*Dc < 0.0) {
+      Tb = Tc;
+      Db = Dc;
+    } else {
+      Ta = Tc;
+      Da = Dc;
+    } 
+  }
+  
+  G4cout << 
+    "G4StatMFMicrocanoncal::CalcEntropyOfCompoundNucleus: I can't calculate the temperature" 
+	 << G4endl;
+  
+  return 0.0;
+}
+
+G4StatMFChannel *  G4StatMFMicroCanonical::ChooseAandZ(const G4Fragment & theFragment)
+  // Choice of fragment atomic numbers and charges 
+{
+  // We choose a multiplicity (1,2,3,...) and then a channel
+  G4double RandNumber = G4UniformRand();
+
+  if (RandNumber < _WCompoundNucleus) { 
+	
+    G4StatMFChannel * aChannel = new G4StatMFChannel;
+    aChannel->CreateFragment(theFragment.GetA_asInt(),theFragment.GetZ_asInt());
+    return aChannel;
+	
+  } else {
+	
+    G4double AccumWeight = _WCompoundNucleus;
+    std::vector<G4StatMFMicroManager*>::iterator it;
+    for (it = _ThePartitionManagerVector.begin(); it != _ThePartitionManagerVector.end(); ++it) {
+      AccumWeight += (*it)->GetProbability();
+      if (RandNumber < AccumWeight) {
+	return (*it)->ChooseChannel(theFragment.GetA_asInt(),theFragment.GetZ_asInt(),__MeanTemperature);
+      }
+    }
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroCanonical::ChooseAandZ: wrong normalization!");
+  }
+
+  return 0;	
+}
+
+G4double G4StatMFMicroCanonical::CalcInvLevelDensity(G4int anA)
+{
+  G4double res = 0.0;
+  if (anA > 1) {
+    res = G4StatMFParameters::GetEpsilon0()*(1.0+3.0/(anA - 1.0));
+  }
+  return res;
+}

--- a/Multifragmentation/src/G4StatMFMicroManager.cc
+++ b/Multifragmentation/src/G4StatMFMicroManager.cc
@@ -1,0 +1,187 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4StatMFMicroManager.hh"
+#include "G4HadronicException.hh"
+
+// Copy constructor
+G4StatMFMicroManager::G4StatMFMicroManager(const G4StatMFMicroManager & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroManager::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4StatMFMicroManager & G4StatMFMicroManager::
+operator=(const G4StatMFMicroManager & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroManager::operator= meant to not be accessable");
+    return *this;
+}
+
+
+G4bool G4StatMFMicroManager::operator==(const G4StatMFMicroManager & ) const
+{
+    return false;
+}
+ 
+
+G4bool G4StatMFMicroManager::operator!=(const G4StatMFMicroManager & ) const
+{
+    return true;
+}
+
+// constructor
+G4StatMFMicroManager::G4StatMFMicroManager(const G4Fragment & theFragment, 
+					   G4int multiplicity,
+					   G4double FreeIntE, G4double SCompNuc) : 
+  _Normalization(0.0)
+{
+  // Perform class initialization
+  Initialize(theFragment,multiplicity,FreeIntE,SCompNuc);
+}
+
+// destructor
+G4StatMFMicroManager::~G4StatMFMicroManager() 
+{
+  if (!_Partition.empty()) 
+    {
+      std::for_each(_Partition.begin(),_Partition.end(),
+		      DeleteFragment());
+    }
+}
+
+void G4StatMFMicroManager::Initialize(const G4Fragment & theFragment, G4int im, 
+				      G4double FreeIntE, G4double SCompNuc) 
+{
+  G4int i;
+
+  G4double U = theFragment.GetExcitationEnergy();
+
+  G4int A = theFragment.GetA_asInt();
+  G4int Z = theFragment.GetZ_asInt();
+	
+  // Statistical weights
+  _WW = 0.0;
+
+  // Mean breakup multiplicity
+  _MeanMultiplicity = 0.0;
+
+  // Mean channel temperature
+  _MeanTemperature = 0.0;
+
+  // Mean channel entropy
+  _MeanEntropy = 0.0;	
+	
+  // Keep fragment atomic numbers
+  // 	G4int * FragmentAtomicNumbers = new G4int(static_cast<G4int>(A+0.5));
+  //	G4int * FragmentAtomicNumbers = new G4int(m);
+  G4int FragmentAtomicNumbers[4];
+	
+  // We distribute A nucleons between m fragments mantaining the order
+  // FragmentAtomicNumbers[m-1]>FragmentAtomicNumbers[m-2]>...>FragmentAtomicNumbers[0]
+  // Our initial distribution is 
+  // FragmentAtomicNumbers[m-1]=A, FragmentAtomicNumbers[m-2]=0, ..., FragmentAtomicNumbers[0]=0
+  FragmentAtomicNumbers[im-1] = A;
+  for (i = 0; i <  (im - 1); i++) FragmentAtomicNumbers[i] = 0;
+
+  // We try to distribute A nucleons in partitions of m fragments
+  // MakePartition return true if it is possible 
+  // and false if it is not	
+
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (MakePartition(im,FragmentAtomicNumbers)) {
+    // Allowed partitions are stored and its probability calculated
+			
+    G4StatMFMicroPartition * aPartition = new G4StatMFMicroPartition(A,Z);
+    G4double PartitionProbability = 0.0;
+			
+    for (i = im-1; i >= 0; i--) aPartition->SetPartitionFragment(FragmentAtomicNumbers[i]);
+    PartitionProbability = aPartition->CalcPartitionProbability(U,FreeIntE,SCompNuc);
+    _Partition.push_back(aPartition);
+			
+    _WW += PartitionProbability;
+    _MeanMultiplicity += im*PartitionProbability;
+    _MeanTemperature += aPartition->GetTemperature() * PartitionProbability;
+    if (PartitionProbability > 0.0) 
+      _MeanEntropy += PartitionProbability * aPartition->GetEntropy();
+  }
+}
+
+G4bool G4StatMFMicroManager::MakePartition(G4int k, G4int * ANumbers)
+// Distributes A nucleons between k fragments
+// mantaining the order ANumbers[k-1] > ANumbers[k-2] > ... > ANumbers[0]
+// If it is possible returns true. In other case returns false
+{
+  G4int l = 1;
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (l < k) {
+    G4int tmp = ANumbers[l-1] + ANumbers[k-1];
+    ANumbers[l-1] += 1;
+    ANumbers[k-1] -= 1;
+    if (ANumbers[l-1] > ANumbers[l] || ANumbers[k-2] > ANumbers[k-1]) {
+      ANumbers[l-1] = 1;
+      ANumbers[k-1] = tmp - 1;
+      l++;
+    } else return true;
+  }
+  return false;
+}
+
+void G4StatMFMicroManager::Normalize(G4double Norm)
+{
+  _Normalization = Norm;
+  _WW /= Norm;
+  _MeanMultiplicity /= Norm;
+  _MeanTemperature /= Norm;
+  _MeanEntropy /= Norm; 
+	
+  return;
+}
+
+G4StatMFChannel* 
+G4StatMFMicroManager::ChooseChannel(G4int A0, G4int Z0, G4double MeanT)
+{
+  G4double RandNumber = _Normalization * _WW * G4UniformRand();
+  G4double AccumWeight = 0.0;
+	
+  for (std::vector<G4StatMFMicroPartition*>::iterator i = _Partition.begin();
+       i != _Partition.end(); ++i)
+    {
+	AccumWeight += (*i)->GetProbability();
+	if (RandNumber < AccumWeight)
+	  return (*i)->ChooseZ(A0,Z0,MeanT);
+    }
+
+  throw G4HadronicException(__FILE__, __LINE__, 
+			    "G4StatMFMicroCanonical::ChooseChannel: Couldn't find a channel.");
+  return 0;
+}

--- a/Multifragmentation/src/G4StatMFMicroPartition.cc
+++ b/Multifragmentation/src/G4StatMFMicroPartition.cc
@@ -1,0 +1,358 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// by V. Lara
+// --------------------------------------------------------------------
+
+#include "G4StatMFMicroPartition.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4HadronicException.hh"
+#include "Randomize.hh"
+#include "G4Log.hh"
+#include "G4Exp.hh"
+#include "G4Pow.hh"
+
+// Copy constructor
+G4StatMFMicroPartition::G4StatMFMicroPartition(const G4StatMFMicroPartition & )
+{
+  throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroPartition::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4StatMFMicroPartition & G4StatMFMicroPartition::
+operator=(const G4StatMFMicroPartition & )
+{
+  throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroPartition::operator= meant to not be accessable");
+  return *this;
+}
+
+
+G4bool G4StatMFMicroPartition::operator==(const G4StatMFMicroPartition & ) const
+{
+  //throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroPartition::operator== meant to not be accessable");
+  return false;
+}
+ 
+
+G4bool G4StatMFMicroPartition::operator!=(const G4StatMFMicroPartition & ) const
+{
+  //throw G4HadronicException(__FILE__, __LINE__, "G4StatMFMicroPartition::operator!= meant to not be accessable");
+  return true;
+}
+
+void G4StatMFMicroPartition::CoulombFreeEnergy(G4int anA)
+{
+  // This Z independent factor in the Coulomb free energy 
+  G4double  CoulombConstFactor = G4StatMFParameters::GetCoulomb();
+
+  // We use the aproximation Z_f ~ Z/A * A_f
+
+  G4double ZA = G4double(theZ)/G4double(theA);
+										
+  if (anA == 0 || anA == 1) 
+    {
+      _theCoulombFreeEnergy.push_back(CoulombConstFactor*ZA*ZA);
+    } 
+  else if (anA == 2 || anA == 3 || anA == 4) 
+    {
+      // Z/A ~ 1/2
+      _theCoulombFreeEnergy.push_back(CoulombConstFactor*0.5
+				      *anA*G4Pow::GetInstance()->Z23(anA));
+    } 
+  else  // anA > 4
+    {
+      _theCoulombFreeEnergy.push_back(CoulombConstFactor*ZA*ZA	
+				      *anA*G4Pow::GetInstance()->Z23(anA));
+    }
+}
+
+G4double G4StatMFMicroPartition::GetCoulombEnergy(void)
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double  CoulombFactor = 1.0/g4calc->A13(1.0+G4StatMFParameters::GetKappaCoulomb());	
+			
+  G4double CoulombEnergy = elm_coupling*0.6*theZ*theZ*CoulombFactor/
+    (G4StatMFParameters::Getr0()*g4calc->Z13(theA));
+	
+  G4double ZA = G4double(theZ)/G4double(theA);
+  for (unsigned int i = 0; i < _thePartition.size(); i++) 
+    CoulombEnergy += _theCoulombFreeEnergy[i] - elm_coupling*0.6*
+      ZA*ZA*_thePartition[i]*g4calc->Z23(_thePartition[i])/
+      G4StatMFParameters::Getr0();
+		
+  return CoulombEnergy;
+}
+
+G4double G4StatMFMicroPartition::GetPartitionEnergy(G4double T)
+{
+  G4Pow* g4calc = G4Pow::GetInstance();
+  G4double  CoulombFactor = 1.0/g4calc->A13(1.0+G4StatMFParameters::GetKappaCoulomb());	
+  
+  G4double PartitionEnergy = 0.0;
+  
+  // We use the aprox that Z_f ~ Z/A * A_f
+  for (unsigned int i = 0; i < _thePartition.size(); i++) 
+    {
+      if (_thePartition[i] == 0 || _thePartition[i] == 1) 
+        {	
+          PartitionEnergy += _theCoulombFreeEnergy[i];
+        }
+      else if (_thePartition[i] == 2) 
+        {		
+          PartitionEnergy +=	
+            -2.796 // Binding Energy of deuteron ??????
+            + _theCoulombFreeEnergy[i];		
+	}
+      else if (_thePartition[i] == 3) 
+        {	
+          PartitionEnergy +=	
+            -9.224 // Binding Energy of trtion/He3 ??????
+            + _theCoulombFreeEnergy[i];		
+	} 
+      else if (_thePartition[i] == 4) 
+        {	
+          PartitionEnergy +=
+            -30.11 // Binding Energy of ALPHA ??????
+            + _theCoulombFreeEnergy[i] 
+            + 4.*T*T/InvLevelDensity(4.);
+	} 
+      else 
+        {
+          PartitionEnergy +=
+            //Volume term						
+            (- G4StatMFParameters::GetE0() + 
+             T*T/InvLevelDensity(_thePartition[i]))
+            *_thePartition[i] + 
+            
+            // Symmetry term
+            G4StatMFParameters::GetGamma0()*
+            (1.0-2.0*theZ/theA)*(1.0-2.0*theZ/theA)*_thePartition[i] +  
+            
+            // Surface term
+            (G4StatMFParameters::Beta(T) - T*G4StatMFParameters::DBetaDT(T))*
+            g4calc->Z23(_thePartition[i]) +
+            
+            // Coulomb term 
+            _theCoulombFreeEnergy[i];
+	}
+    }
+	
+  PartitionEnergy += elm_coupling*0.6*theZ*theZ*CoulombFactor/
+    (G4StatMFParameters::Getr0()*g4calc->Z13(theA))
+    + 1.5*T*(_thePartition.size()-1);
+  
+  return PartitionEnergy;
+}
+
+G4double G4StatMFMicroPartition::CalcPartitionTemperature(G4double U,
+							  G4double FreeInternalE0)
+{
+  G4double PartitionEnergy = GetPartitionEnergy(0.0);
+  
+  // If this happens, T = 0 MeV, which means that probability for this
+  // partition will be 0
+  if (std::fabs(U + FreeInternalE0 - PartitionEnergy) < 0.003) return -1.0;
+    
+  // Calculate temperature by midpoint method
+	
+  // Bracketing the solution
+  G4double Ta = 0.001;
+  G4double Tb = std::max(std::sqrt(8.0*U/theA),0.0012*MeV);
+  G4double Tmid = 0.0;
+  
+  G4double Da = (U + FreeInternalE0 - GetPartitionEnergy(Ta))/U;
+  G4double Db = (U + FreeInternalE0 - GetPartitionEnergy(Tb))/U;
+  
+  G4int maxit = 0;
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (Da*Db > 0.0 && maxit < 1000) 
+    {
+      ++maxit;
+      Tb += 0.5*Tb; 	
+      Db = (U + FreeInternalE0 - GetPartitionEnergy(Tb))/U;
+    }
+  
+  G4double eps = 1.0e-14*std::abs(Ta-Tb);
+  
+  for (G4int i = 0; i < 1000; i++) 
+    {
+      Tmid = (Ta+Tb)/2.0;
+      if (std::fabs(Ta-Tb) <= eps) return Tmid;
+      G4double Dmid = (U + FreeInternalE0 - GetPartitionEnergy(Tmid))/U;
+      if (std::fabs(Dmid) < 0.003) return Tmid;
+      if (Da*Dmid < 0.0) 
+        {
+          Tb = Tmid;
+          Db = Dmid;
+        } 
+      else 
+        {
+          Ta = Tmid;
+          Da = Dmid;
+        } 
+    }
+  // if we arrive here the temperature could not be calculated
+  G4cout << "G4StatMFMicroPartition::CalcPartitionTemperature: I can't calculate the temperature"  
+         << G4endl;
+  // and set probability to 0 returning T < 0
+  return -1.0;
+  
+}
+
+G4double G4StatMFMicroPartition::CalcPartitionProbability(G4double U,
+							  G4double FreeInternalE0,
+							  G4double SCompound)
+{	
+  G4double T = CalcPartitionTemperature(U,FreeInternalE0);
+  if ( T <= 0.0) return _Probability = 0.0;
+  _Temperature = T;
+  
+  G4Pow* g4calc = G4Pow::GetInstance();
+  
+  // Factorial of fragment multiplicity
+  G4double Fact = 1.0;
+  unsigned int i;
+  for (i = 0; i < _thePartition.size() - 1; i++) 
+    {
+      G4double f = 1.0;
+      for (unsigned int ii = i+1; i< _thePartition.size(); i++) 
+        {
+          if (_thePartition[i] == _thePartition[ii]) f++;
+        }
+      Fact *= f;
+  }
+	
+  G4double ProbDegeneracy = 1.0;
+  G4double ProbA32 = 1.0;	
+	
+  for (i = 0; i < _thePartition.size(); i++) 
+    {
+      ProbDegeneracy *= GetDegeneracyFactor(_thePartition[i]);
+      ProbA32 *= _thePartition[i]*std::sqrt((G4double)_thePartition[i]);
+    }
+	
+  // Compute entropy
+  G4double PartitionEntropy = 0.0;
+  for (i = 0; i < _thePartition.size(); i++) 
+    {
+      // interaction entropy for alpha
+      if (_thePartition[i] == 4) 
+        {
+          PartitionEntropy += 
+            2.0*T*_thePartition[i]/InvLevelDensity(_thePartition[i]);
+        }
+      // interaction entropy for Af > 4
+      else if (_thePartition[i] > 4) 
+        {
+          PartitionEntropy += 
+            2.0*T*_thePartition[i]/InvLevelDensity(_thePartition[i])
+            - G4StatMFParameters::DBetaDT(T) * g4calc->Z23(_thePartition[i]);
+        } 
+    }
+	
+  // Thermal Wave Lenght = std::sqrt(2 pi hbar^2 / nucleon_mass T)
+  G4double ThermalWaveLenght3 = 16.15*fermi/std::sqrt(T);
+  ThermalWaveLenght3 = ThermalWaveLenght3*ThermalWaveLenght3*ThermalWaveLenght3;
+  
+  // Translational Entropy
+  G4double kappa = 1. + elm_coupling*(g4calc->Z13(_thePartition.size())-1.0)
+                    /(G4StatMFParameters::Getr0()*g4calc->Z13(theA));
+  kappa = kappa*kappa*kappa;
+  kappa -= 1.;
+  G4double V0 = (4./3.)*pi*theA*G4StatMFParameters::Getr0()*G4StatMFParameters::Getr0()*
+    G4StatMFParameters::Getr0();
+  G4double FreeVolume = kappa*V0;
+  G4double TranslationalS = std::max(0.0, G4Log(ProbA32/Fact) +
+      (_thePartition.size()-1.0)*G4Log(FreeVolume/ThermalWaveLenght3) +
+      1.5*(_thePartition.size()-1.0) - 1.5*g4calc->logZ(theA));
+  
+  PartitionEntropy += G4Log(ProbDegeneracy) + TranslationalS;
+  _Entropy = PartitionEntropy;
+	
+  // And finally compute probability of fragment configuration
+  G4double exponent = PartitionEntropy-SCompound;
+  if (exponent > 300.0) exponent = 300.0;
+  return _Probability = G4Exp(exponent);
+}
+
+G4double G4StatMFMicroPartition::GetDegeneracyFactor(G4int A)
+{
+  // Degeneracy factors are statistical factors
+  // DegeneracyFactor for nucleon is (2S_n + 1)(2I_n + 1) = 4
+  G4double DegFactor = 0;
+  if (A > 4) DegFactor = 1.0;
+  else if (A == 1) DegFactor = 4.0;     // nucleon
+  else if (A == 2) DegFactor = 3.0;     // Deuteron
+  else if (A == 3) DegFactor = 4.0;     // Triton + He3
+  else if (A == 4) DegFactor = 1.0;     // alpha
+  return DegFactor;
+}
+
+G4StatMFChannel * G4StatMFMicroPartition::ChooseZ(G4int A0, G4int Z0, G4double MeanT)
+// Gives fragments charges
+{
+  std::vector<G4int> FragmentsZ;
+  
+  G4int ZBalance = 0;
+  do 
+    {
+      G4double CC = G4StatMFParameters::GetGamma0()*8.0;
+      G4int SumZ = 0;
+      for (unsigned int i = 0; i < _thePartition.size(); i++) 
+        {
+          G4double ZMean;
+          G4double Af = _thePartition[i];
+          if (Af > 1.5 && Af < 4.5) ZMean = 0.5*Af;
+          else ZMean = Af*Z0/A0;
+          G4double ZDispersion = std::sqrt(Af * MeanT/CC);
+          G4int Zf;
+          do 
+            {
+              Zf = static_cast<G4int>(G4RandGauss::shoot(ZMean,ZDispersion));
+	    } 
+          // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+          while (Zf < 0 || Zf > Af);
+          FragmentsZ.push_back(Zf);
+          SumZ += Zf;
+	}
+      ZBalance = Z0 - SumZ;
+    } 
+  // Loop checking, 05-Aug-2015, Vladimir Ivanchenko
+  while (std::abs(ZBalance) > 1);
+  FragmentsZ[0] += ZBalance;
+	
+  G4StatMFChannel * theChannel = new G4StatMFChannel;
+  for (unsigned int i = 0; i < _thePartition.size(); i++)
+    {
+      theChannel->CreateFragment(_thePartition[i],FragmentsZ[i]);
+    }
+
+  return theChannel;
+}

--- a/Multifragmentation/src/G4StatMFParameters.cc
+++ b/Multifragmentation/src/G4StatMFParameters.cc
@@ -1,0 +1,146 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+
+#include "G4StatMFParameters.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4PhysicalConstants.hh"
+
+const G4double G4StatMFParameters::fKappa = 1.0; // dimensionless
+
+const G4double G4StatMFParameters::fKappaCoulomb = 2.0; // dimensionless
+
+const G4double G4StatMFParameters::fEpsilon0 = 16.0*MeV;
+
+// Bethe-Weizsacker coefficients
+const G4double G4StatMFParameters::fE0 = 16.0*MeV;
+
+const G4double G4StatMFParameters::fBeta0 = 18.0*MeV;
+
+const G4double G4StatMFParameters::fGamma0 = 25.0*MeV;
+
+// Critical temperature (for liquid-gas phase transitions)
+const G4double G4StatMFParameters::fCriticalTemp = 18.0*MeV;
+
+// Nuclear radius
+const G4double G4StatMFParameters::fr0 = 1.17*fermi;
+
+const G4double G4StatMFParameters::fCoulomb = 0.6*(CLHEP::elm_coupling/fr0)*
+  (1.0 - 1.0/std::pow(1.0+fKappaCoulomb,1./3.));
+
+G4StatMFParameters::G4StatMFParameters()
+{}
+
+G4StatMFParameters::~G4StatMFParameters()
+{}
+
+G4double G4StatMFParameters::GetKappa()
+{ 
+  return fKappa; 
+}
+  
+G4double G4StatMFParameters::GetKappaCoulomb()  
+{ 
+  return fKappaCoulomb; 
+} 
+  
+G4double G4StatMFParameters::GetEpsilon0() 
+{ 
+  return fEpsilon0; 
+}
+  
+G4double G4StatMFParameters::GetE0() 
+{ 
+  return fE0; 
+}
+  
+G4double G4StatMFParameters::GetBeta0() 
+{ 
+  return fBeta0; 
+} 
+  
+G4double G4StatMFParameters::GetGamma0() 
+{ 
+  return fGamma0; 
+}
+  
+G4double G4StatMFParameters::GetCriticalTemp()  
+{ 
+  return fCriticalTemp; 
+}
+  
+G4double G4StatMFParameters::Getr0() 
+{ 
+  return fr0; 
+}
+
+G4double G4StatMFParameters::GetCoulomb() 
+{ 
+  return fCoulomb; 
+}
+
+G4double G4StatMFParameters::Beta(G4double T) 
+{
+  G4double res = 0.0;
+  if (T < fCriticalTemp) {
+    G4double CriticalTempSqr = fCriticalTemp*fCriticalTemp;
+    G4double TempSqr = T*T;
+    G4double tmp = (CriticalTempSqr-TempSqr)/(CriticalTempSqr+TempSqr);
+		
+    res = fBeta0*tmp*std::pow(tmp,0.25);
+  }
+  return res;
+}
+
+G4double G4StatMFParameters::DBetaDT(G4double T) 
+{
+  G4double res = 0.0;
+  if (T < fCriticalTemp) {
+    G4double CriticalTempSqr = fCriticalTemp*fCriticalTemp;
+    G4double TempSqr = T*T;
+    G4double tmp = (CriticalTempSqr-TempSqr)/(CriticalTempSqr+TempSqr);
+		
+    res = -5.0*fBeta0*std::pow(tmp,0.25)*(CriticalTempSqr*T)/
+      ((CriticalTempSqr+TempSqr)*(CriticalTempSqr+TempSqr));
+  }
+  return res;
+}
+
+G4double 
+G4StatMFParameters::GetMaxAverageMultiplicity(G4int A) 
+{
+  // Maximun average multiplicity: M_0 = 2.6 for A ~ 200 
+  // and M_0 = 3.3 for A <= 110
+  G4double MaxAverageMultiplicity = 2.6;
+  if (A <= 110) { MaxAverageMultiplicity = 3.3; }
+  return MaxAverageMultiplicity;
+}
+

--- a/Multifragmentation/src/G4VMultiFragmentation.cc
+++ b/Multifragmentation/src/G4VMultiFragmentation.cc
@@ -1,0 +1,40 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara (Nov 1998)
+
+#include "G4VMultiFragmentation.hh"
+#include "G4HadronicException.hh"
+
+G4VMultiFragmentation::G4VMultiFragmentation()
+{}
+
+G4VMultiFragmentation::~G4VMultiFragmentation()
+{}
+

--- a/Multifragmentation/src/G4VStatMFEnsemble.cc
+++ b/Multifragmentation/src/G4VStatMFEnsemble.cc
@@ -1,0 +1,63 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4VStatMFEnsemble.hh"
+#include "G4HadronicException.hh"
+
+// Copy constructor
+G4VStatMFEnsemble::G4VStatMFEnsemble(const G4VStatMFEnsemble & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFEnsemble::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4VStatMFEnsemble & G4VStatMFEnsemble::
+operator=(const G4VStatMFEnsemble & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFEnsemble::operator= meant to not be accessable");
+    return *this;
+}
+
+
+G4bool G4VStatMFEnsemble::operator==(const G4VStatMFEnsemble & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFEnsemble::operator== meant to not be accessable");
+    return false;
+}
+ 
+
+G4bool G4VStatMFEnsemble::operator!=(const G4VStatMFEnsemble & ) const
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFEnsemble::operator!= meant to not be accessable");
+    return true;
+}
+

--- a/Multifragmentation/src/G4VStatMFMacroCluster.cc
+++ b/Multifragmentation/src/G4VStatMFMacroCluster.cc
@@ -1,0 +1,74 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id$
+//
+// Hadronic Process: Nuclear De-excitations
+// by V. Lara
+
+#include "G4VStatMFMacroCluster.hh"
+
+
+
+// Copy constructor
+G4VStatMFMacroCluster::G4VStatMFMacroCluster(const G4VStatMFMacroCluster & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFMacroCluster::copy_constructor meant to not be accessable");
+}
+
+// Operators
+
+G4VStatMFMacroCluster & G4VStatMFMacroCluster::
+operator=(const G4VStatMFMacroCluster & )
+{
+    throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFMacroCluster::operator= meant to not be accessable");
+    return *this;
+}
+
+
+G4bool G4VStatMFMacroCluster::operator==(const G4VStatMFMacroCluster & ) const
+{
+//	throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFMacroCluster::operator== meant to not be accessable");
+    return false;
+}
+ 
+
+G4bool G4VStatMFMacroCluster::operator!=(const G4VStatMFMacroCluster & ) const
+{
+//	throw G4HadronicException(__FILE__, __LINE__, "G4VStatMFMacroCluster::operator!= meant to not be accessable");
+    return true;
+}
+
+
+G4double G4VStatMFMacroCluster::CalcInvLevelDensity(void)
+{
+    // Calculate Inverse Density Level
+    // Epsilon0*(1 + 3 /(Af - 1))
+    if (theA == 1) return 0.0;
+    else return
+	     G4StatMFParameters::GetEpsilon0()*(1.0+3.0/(static_cast<G4double>(theA-1)));
+}
+

--- a/include/FermiMomentum.hh
+++ b/include/FermiMomentum.hh
@@ -27,7 +27,7 @@ private:
     //Goldhaber model parameter
     double GoldhaberDev0 = 193*MeV;
     //Morissey model parameter
-    double MorisseyDev0 = 400*MeV;
+    double MorisseyDev0 = 150*MeV;
     //VanBiber model parameter
     double VBDev1 = 146*MeV;
 

--- a/include/GRATEmanager.hh
+++ b/include/GRATEmanager.hh
@@ -31,6 +31,7 @@ class GRATEmanager
   TH1D* GetHisto(G4int id) {return histo[id];};
   TTree* GetTree() {return Glauber;};
   TTree* GetTreeMST() {return Clusters;};
+  TTree* GetTreeFermiMom() {return FermiMom;};
   TH2D* GetHisto2(G4int id) {return histo2[id];};
  
        
@@ -72,58 +73,59 @@ class GRATEmanager
   private:
 
   
-    TFile* fFile;
-    TH1D*  histo[20];
-    TH2D*  histo2[10];
-    TTree* Glauber;
-    TTree* modelingCo;
-    TTree* Clusters;
- 
+  TFile* fFile;
+  TH1D*  histo[20];
+  TH2D*  histo2[10];
+  TTree* Glauber;
+  TTree* modelingCo;
+  TTree* Clusters;
+  TTree* FermiMom;
 
-    G4int sourceZ;
-    G4int sourceA;
-    G4int sourceZb;
-    G4int sourceAb;
-    G4int iterations; 
-    G4int StatisticsLabel;  
-    G4bool NucleusInputLabel;
-    G4bool IsCollider;
-    G4bool InFileOrNot;
 
-    G4String fileName;
-    G4String fileType;
-    G4String fileOpenPath;
+  G4int sourceZ;
+  G4int sourceA;
+  G4int sourceZb;
+  G4int sourceAb;
+  G4int iterations; 
+  G4int StatisticsLabel;  
+  G4bool NucleusInputLabel;
+  G4bool IsCollider;
+  G4bool InFileOrNot;
 
-    G4String     fileFullName;
-    G4String     SysA;
-    G4String     SysB;
-    G4int        compressionFactor;
+  G4String fileName;
+  G4String fileType;
+  G4String fileOpenPath;
 
-    G4double XsectNN;
+  G4String     fileFullName;
+  G4String     SysA;
+  G4String     SysB;
+  G4int        compressionFactor;
 
-    G4double KinEn;
-    G4double PzA;
-    G4double PzB;
-    G4double lowLimitExEn;
-    G4double upperLimitExEn;
-    G4double lowLimitExEnB;
-    G4double upperLimitExEnB;
-    G4double lowLimitB;
-    G4double upperLimitB;
-    G4int    binsExEn;
-    G4int    eventsPerBin;
+  G4double XsectNN;
 
-    G4double CritDist;
-    G4double angle;
+  G4double KinEn;
+  G4double PzA;
+  G4double PzB;
+  G4double lowLimitExEn;
+  G4double upperLimitExEn;
+  G4double lowLimitExEnB;
+  G4double upperLimitExEnB;
+  G4double lowLimitB;
+  G4double upperLimitB;
+  G4int    binsExEn;
+  G4int    eventsPerBin;
 
-    G4double nucleonAverMass = 0.931494*CLHEP::GeV;
+  G4double CritDist;
+  G4double angle;
 
-    G4bool   wM;
-    G4bool   wP = false;
+  G4double nucleonAverMass = 0.931494*CLHEP::GeV;
 
-    InitialConditions* InCond = new InitialConditions();
+  G4bool   wM;
+  G4bool   wP = false;
 
-    std::ifstream XsectFile;
+  InitialConditions* InCond = new InitialConditions();
+
+  std::ifstream XsectFile;
 
 };
 

--- a/src/GMSTClustering.cc
+++ b/src/GMSTClustering.cc
@@ -38,7 +38,7 @@ void GMSTClustering::SetCDExEn(G4double Ex, G4int A) {
    if(Ex/G4double(A) < 2.17*MeV){CritDist = d0;}
    else{//kappa = std::pow(1/(1+aColRel*std::pow(G4double(A),-0.333333333333333333)+aSurfRel*std::pow(G4double(A),-0.666666666666666)),0.3333333333333);
        kappa = 1;
-       CritDist = d0*kappa*std::pow(Ex/(eps0*G4double(A)),0.333333333333333333*alphaPow);}
+       CritDist = d0*kappa*std::pow(Ex/(eps0*G4double(A)),1./3.*alphaPow);}
 }
 
 std::vector<G4FragmentVector> GMSTClustering::GetClusters(NucleonVector* nucleons_in, G4double ExA, G4double ExB, CLHEP::Hep3Vector boostA, CLHEP::Hep3Vector boostB){


### PR DESCRIPTION
1. Уменьшена ширина в распределении Мориссея
2. Исправлено двойное заполнение в гистограммы MST, исправлено отсутствие заполнения числа кластеров, добавлено дерево Fermi импульсов, добавлена гистограмма ExEn VS d
3. 0.3333 -> 1./3.
4. Добавлена подгрузка файлов мультифрагментации (geant4.10.04.p03) с исправлением в розыгрыше импульсов. Теперь один заряженный фрагмент не ускоряется в собственном кулоновском поле
5. Улучшена читаемость кода за счёт табуляции