### PR TITLE
Fermi mom and ex en param fix

### DIFF
--- a/GRATE.cc
+++ b/GRATE.cc
@@ -260,7 +260,7 @@ int main()
 
     NucleonVector nV;
     GlauberCollisionReader reader;
-    FermiMomentum FermiMom(&nV, "M");
+    FermiMomentum FermiMom(&nV, "G");
     FermiMom.SetPzPerNucleon(histoManager.GetInitialContidions().GetPzA()/ sourceA, histoManager.GetInitialContidions().GetPzB() / sourceAb);
 
     for(G4int count=0;count<histoManager.GetIterations() ;count++){ 

--- a/GRATE.cc
+++ b/GRATE.cc
@@ -260,7 +260,7 @@ int main()
 
     NucleonVector nV;
     GlauberCollisionReader reader;
-    FermiMomentum FermiMom(&nV, "G");
+    FermiMomentum FermiMom(&nV, "M");
     FermiMom.SetPzPerNucleon(histoManager.GetInitialContidions().GetPzA()/ sourceA, histoManager.GetInitialContidions().GetPzB() / sourceAb);
 
     for(G4int count=0;count<histoManager.GetIterations() ;count++){ 

--- a/GRATE.cc
+++ b/GRATE.cc
@@ -245,17 +245,17 @@ int main()
         //Parameters for ALADIN parametrization
         G4double e_0=11.5*MeV;//was 8.13 MeV
         G4double sigma0 = 0.005; //was 0.01
-        G4double b0 = 2; // From Bondorf 1995
+        G4double c0 = 2; // From Bondorf 1995
         G4double sigmaE0 = 1*MeV;
-        G4double c0 = 0.1;
+        G4double b0 = 0.1;
         G4double Pe = 24*MeV;
         G4double Pm = 0.2;
-        ExEnA->SetParametersALADIN(e_0,sigma0,b0);
-        ExEnB->SetParametersALADIN(e_0,sigma0,b0);
+        ExEnA->SetParametersALADIN(e_0,sigma0,c0);
+        ExEnB->SetParametersALADIN(e_0,sigma0,c0);
         ExEnA->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
         ExEnB->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
-        //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,c0,0);
-        //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,c0,0);
+        //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
+        //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
     }
 
     NucleonVector nV;
@@ -308,10 +308,10 @@ int main()
             ExEn = energy_A/G4double(A);
             histoManager.GetHisto2(1)->Fill(ExEn, G4double(A)/sourceA);
 
-            FermiMomA_x = FermiMom.GetBoost("A").getX() * 931.494*CLHEP::MeV * A / pow((1-FermiMom.GetBoost("A").mag2()), 0.5);
-            FermiMomA_y = FermiMom.GetBoost("A").getY() * 931.494*CLHEP::MeV * A / pow((1-FermiMom.GetBoost("A").mag2()), 0.5);
-            FermiMomB_x = FermiMom.GetBoost("B").getX() * 931.494*CLHEP::MeV * Ab / pow((1-FermiMom.GetBoost("B").mag2()), 0.5);
-            FermiMomB_y = FermiMom.GetBoost("B").getY() * 931.494*CLHEP::MeV * Ab / pow((1-FermiMom.GetBoost("B").mag2()), 0.5);
+            FermiMomA_x = FermiMom.GetBoost("A").getX();
+            FermiMomA_y = FermiMom.GetBoost("A").getY();
+            FermiMomB_x = FermiMom.GetBoost("B").getX();
+            FermiMomB_y = FermiMom.GetBoost("B").getY();
 
             std::vector<G4FragmentVector> MstClustersVector = clusters->GetClusters(&nV, energy_A, energy_B, FermiMom.GetBoost("A"), FermiMom.GetBoost("B")); //d = const if energy is negative
             G4FragmentVector clusters_to_excit_A = MstClustersVector.at(0);

--- a/GRATE.cc
+++ b/GRATE.cc
@@ -245,17 +245,17 @@ int main()
         //Parameters for ALADIN parametrization
         G4double e_0=11.5*MeV;//was 8.13 MeV
         G4double sigma0 = 0.005; //was 0.01
-        G4double c0 = 2; // From Bondorf 1995
+        G4double b0 = 2; // From Bondorf 1995
         G4double sigmaE0 = 1*MeV;
-        G4double b0 = 0.1;
+        G4double c0 = 0.1;
         G4double Pe = 24*MeV;
         G4double Pm = 0.2;
-        ExEnA->SetParametersALADIN(e_0,sigma0,c0);
-        ExEnB->SetParametersALADIN(e_0,sigma0,c0);
+        ExEnA->SetParametersALADIN(e_0,sigma0,b0);
+        ExEnB->SetParametersALADIN(e_0,sigma0,b0);
         ExEnA->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
         ExEnB->SetParametersParabolicApproximation(Pe, Pm, sigma0, b0, 0.01);
-        //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
-        //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,b0,0);
+        //ExEnA->SetParametersCorrectedALADIN(0.01,1000,sigma0,c0,0);
+        //ExEnB->SetParametersCorrectedALADIN(0.01,1000,sigma0,c0,0);
     }
 
     NucleonVector nV;
@@ -308,10 +308,10 @@ int main()
             ExEn = energy_A/G4double(A);
             histoManager.GetHisto2(1)->Fill(ExEn, G4double(A)/sourceA);
 
-            FermiMomA_x = FermiMom.GetBoost("A").getX();
-            FermiMomA_y = FermiMom.GetBoost("A").getY();
-            FermiMomB_x = FermiMom.GetBoost("B").getX();
-            FermiMomB_y = FermiMom.GetBoost("B").getY();
+            FermiMomA_x = FermiMom.GetBoost("A").getX() * 931.494*CLHEP::MeV * A / pow((1-FermiMom.GetBoost("A").mag2()), 0.5);
+            FermiMomA_y = FermiMom.GetBoost("A").getY() * 931.494*CLHEP::MeV * A / pow((1-FermiMom.GetBoost("A").mag2()), 0.5);
+            FermiMomB_x = FermiMom.GetBoost("B").getX() * 931.494*CLHEP::MeV * Ab / pow((1-FermiMom.GetBoost("B").mag2()), 0.5);
+            FermiMomB_y = FermiMom.GetBoost("B").getY() * 931.494*CLHEP::MeV * Ab / pow((1-FermiMom.GetBoost("B").mag2()), 0.5);
 
             std::vector<G4FragmentVector> MstClustersVector = clusters->GetClusters(&nV, energy_A, energy_B, FermiMom.GetBoost("A"), FermiMom.GetBoost("B")); //d = const if energy is negative
             G4FragmentVector clusters_to_excit_A = MstClustersVector.at(0);

--- a/include/FermiMomentum.hh
+++ b/include/FermiMomentum.hh
@@ -22,6 +22,9 @@ public:
     vect3 GetMomentum(std::string side);
     CLHEP::Hep3Vector GetBoost(std::string side);
     void SetPzPerNucleon(double  pZA, double pZB);
+    vect3 GetGoldhaber();
+    vect3 GetMorrisey();
+    vect3 GetVanBiber();
 
 private:
     //Goldhaber model parameter
@@ -51,9 +54,5 @@ private:
     int modelInt = 0;
     NucleonVector* nucleons;
     vect3 pF = {0, 0, 0};
-
-    vect3 GetGoldhaber();
-    vect3 GetMorrisey();
-    vect3 GetVanBiber();
 
 };

--- a/include/GRATEmanager.hh
+++ b/include/GRATEmanager.hh
@@ -31,6 +31,7 @@ class GRATEmanager
   TH1D* GetHisto(G4int id) {return histo[id];};
   TTree* GetTree() {return Glauber;};
   TTree* GetTreeMST() {return Clusters;};
+  TTree* GetTreeGoldhaber() {return Goldhaber;};
   TTree* GetTreeFermiMom() {return FermiMom;};
   TH2D* GetHisto2(G4int id) {return histo2[id];};
  
@@ -79,6 +80,7 @@ class GRATEmanager
   TTree* Glauber;
   TTree* modelingCo;
   TTree* Clusters;
+  TTree* Goldhaber;
   TTree* FermiMom;
 
 

--- a/src/Ericson.cc
+++ b/src/Ericson.cc
@@ -4,22 +4,17 @@ G4double Ericson(G4double E,G4double EvaporationEnergy, G4int a,G4int A){
   G4double g0=16; //16 was in Shidenberger - not influence calculations at all cause its freeze out in distr normalization. 
   G4int RemovedNucleons = A-a;
 
-if(E>EvaporationEnergy*(A-a)){
-   G4double s=0;  
-  return s; 
+  if(E>EvaporationEnergy*(A-a)){
+    G4double s=0;  
+    return s; 
+  }
+  else
+  {
+    G4double s=g0;
+    for(G4int k = 2; k <= RemovedNucleons; k++){
+      s*=(g0*E)/G4double(k*(k-1));
+    }
+    return s; 
+  }
 }
-else{
-
-G4double s=g0;
-
-for(G4int k = 2; k < RemovedNucleons-1; k++){
-
-s*=(g0*E)/G4double(k*(k-1));
-
-}
-
-
- return s; 
-}
- }
 

--- a/src/ExcitationEnergy.cc
+++ b/src/ExcitationEnergy.cc
@@ -110,9 +110,7 @@ G4double ExcitationEnergy::GetEnergyEricson(G4int A) {
     G4double Ericson(G4double, G4double, G4int ,G4int);
 
     for (G4int n = 0; n < 10000; n++) {
-        G4double sum =
-                Ericson(G4double(n) * ((UpExEn - LowExEn) / G4double(10000)),
-                        Ebound, A, initA) * (UpExEn - LowExEn) / G4double(10000);
+        G4double sum = Ericson(G4double(n) * ((UpExEn - LowExEn) / G4double(10000)), Ebound, A, initA) * (UpExEn - LowExEn) / G4double(10000);
         ExcitationEnergyDistribution[n] = sum;
     }
     CLHEP::RandGeneral randGeneral(ExcitationEnergyDistribution, 10000);

--- a/src/FermiMomentum.cc
+++ b/src/FermiMomentum.cc
@@ -44,14 +44,12 @@ vect3 FermiMomentum::GetMomentum(std::string side) {
                         default: out = GetMorrisey(); break;
                     }
                     pF = {-out.px, -out.py, -out.pz};
-                    out.pz = -gammafacB * (out.pz + betafacB * pow(out.mag2() + pow (nucleonAverMass * (nucleons->GetA(side)), 2), 0.5));
+                    out.pz = gammafacB * (out.pz - betafacB * pow(out.mag2() + pow (nucleonAverMass * (nucleons->GetA(side)), 2), 0.5));
                     return out;
                 }
                 else {out = {-pF.px, -pF.py, -pF.pz}; pF = {0, 0, 0};
-                    out.pz = -gammafacB * (out.pz + betafacB * pow(out.mag2() + pow (nucleonAverMass * (nucleons->GetA(side)), 2), 0.5));
+                    out.pz = gammafacB * (out.pz - betafacB * pow(out.mag2() + pow (nucleonAverMass * (nucleons->GetA(side)), 2), 0.5));
                     return out;}
-
-
         }
         else {std::cout<< "Error, side argument is invalid. Please, use A or B as an argument"; return out;}
 

--- a/src/GRATEmanager.cc
+++ b/src/GRATEmanager.cc
@@ -122,6 +122,7 @@ void GRATEmanager::BookHisto()
   Glauber = new TTree("Glauber","Events from glauber modeling");
   modelingCo = new TTree("Conditions","preconditions for modeling");
   Clusters = new TTree("MST: Clusters info", "TTree to store clusters");
+  Goldhaber = new TTree("Goldhaber_check", "Goldhaber moments");
   FermiMom = new TTree("FermiMomentum_info", "Fermi moments");
   // Book all histograms there ...
   histo[0] =  new TH1D("Charge distruibution for side B"," ;Z;entries",sourceZb+1,-0.5, sourceZb+0.5); 


### PR DESCRIPTION
1. В предыдущей версии в дерево FermiMom записывался не поперечный Ферми импульс, а beta_x, beta_y. Добавлена компонента по z. Исправлена формула для буста в лаб систему z компоненты. Добавлено дерево для проверки розыгрыша импульса по Голдхаберу для системы с 1 партисипантом.
2. Исправлены названия переменных для параметризаций энергии возбуждения, чтобы избежать путаницы
3. Метод розыгрыша поперечных импульсов изменён на опцию Голдхабера из-за аномальных импульсов из формулы Мориссея в периферических столкновениях
4. Исправлена ошибка в вычислении плотности вероятности по формуле Эриксона