### PR TITLE
Initial momenta inversion fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /cmake-build-debug/ 
 /.idea/
+/.vscode/
+/build

--- a/src/GetInitData.cc
+++ b/src/GetInitData.cc
@@ -17,8 +17,8 @@ AAMCCrun getTheRunData(const TString& inputFileName="test.root")
 	runData.AinitB = run->GetATarg();
 	runData.ZinitB = run->GetZTarg();
 
-	runData.pzB = run->GetPProj()*run->GetAProj()*GeV;
-	runData.pzA = run->GetPTarg()*run->GetATarg()*GeV;
+	runData.pzA = run->GetPProj()*run->GetAProj()*GeV;
+	runData.pzB = run->GetPTarg()*run->GetATarg()*GeV;
 
 	runData.SqrtSnn = run->GetNNSqrtS();
 


### PR DESCRIPTION
Fixes the inversion of momentum between Target and Projectile nuclei if reading from McIni file